### PR TITLE
Feature/3 로켓펀치 크롤링 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.jsoup:jsoup:1.14.3'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.jsoup:jsoup:1.14.3'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"

--- a/src/main/java/flab/project/jobfinder/config/JobKoreaConfig.java
+++ b/src/main/java/flab/project/jobfinder/config/JobKoreaConfig.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 public class JobKoreaConfig {
 
     @Bean
-    public QueryParamGenerator jobKoreaQueryParamGenerator(JobKoreaPropertiesConfig config) {
-        return new JobKoreaQueryParamGenerator(config);
+    public QueryParamGenerator jobKoreaQueryParamGenerator() {
+        return new JobKoreaQueryParamGenerator();
     }
 }

--- a/src/main/java/flab/project/jobfinder/config/JobKoreaPropertiesConfig.java
+++ b/src/main/java/flab/project/jobfinder/config/JobKoreaPropertiesConfig.java
@@ -15,5 +15,4 @@ public class JobKoreaPropertiesConfig {
     private String delimiter;
     private String selector;
     private String numSelector;
-    private int maxThreadPool;
 }

--- a/src/main/java/flab/project/jobfinder/config/JobKoreaPropertiesConfig.java
+++ b/src/main/java/flab/project/jobfinder/config/JobKoreaPropertiesConfig.java
@@ -1,18 +1,10 @@
 package flab.project.jobfinder.config;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-@Getter
-@Setter
+
 @Configuration
 @ConfigurationProperties(prefix = "jobkorea")
-public class JobKoreaPropertiesConfig {
-    private String url;
-    private String searchUrl;
-    private String delimiter;
-    private String selector;
-    private String numSelector;
+public class JobKoreaPropertiesConfig extends PropertiesConfig {
 }

--- a/src/main/java/flab/project/jobfinder/config/PropertiesConfig.java
+++ b/src/main/java/flab/project/jobfinder/config/PropertiesConfig.java
@@ -1,0 +1,14 @@
+package flab.project.jobfinder.config;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public abstract class PropertiesConfig {
+    protected String url;
+    protected String searchUrl;
+    protected String delimiter;
+    protected String selector;
+    protected String pageSelector;
+}

--- a/src/main/java/flab/project/jobfinder/config/RocketPunchConfig.java
+++ b/src/main/java/flab/project/jobfinder/config/RocketPunchConfig.java
@@ -4,6 +4,7 @@ import flab.project.jobfinder.service.crawler.generator.QueryParamGenerator;
 import flab.project.jobfinder.service.crawler.generator.RocketPunchQueryParamGenerator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class RocketPunchConfig {
@@ -11,5 +12,13 @@ public class RocketPunchConfig {
     @Bean
     public QueryParamGenerator rocketPunchQueryParamGenerator(RocketPunchPropertiesConfig config) {
         return new RocketPunchQueryParamGenerator(config);
+    }
+
+    @Bean
+    public WebClient webClient(RocketPunchPropertiesConfig config) {
+        String url = config.getSearchUrl();
+        return WebClient.builder()
+                .baseUrl(url)
+                .build();
     }
 }

--- a/src/main/java/flab/project/jobfinder/config/RocketPunchConfig.java
+++ b/src/main/java/flab/project/jobfinder/config/RocketPunchConfig.java
@@ -10,8 +10,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class RocketPunchConfig {
 
     @Bean
-    public QueryParamGenerator rocketPunchQueryParamGenerator(RocketPunchPropertiesConfig config) {
-        return new RocketPunchQueryParamGenerator(config);
+    public QueryParamGenerator rocketPunchQueryParamGenerator() {
+        return new RocketPunchQueryParamGenerator();
     }
 
     @Bean

--- a/src/main/java/flab/project/jobfinder/config/RocketPunchConfig.java
+++ b/src/main/java/flab/project/jobfinder/config/RocketPunchConfig.java
@@ -1,0 +1,15 @@
+package flab.project.jobfinder.config;
+
+import flab.project.jobfinder.service.crawler.generator.QueryParamGenerator;
+import flab.project.jobfinder.service.crawler.generator.RocketPunchQueryParamGenerator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RocketPunchConfig {
+
+    @Bean
+    public QueryParamGenerator rocketPunchQueryParamGenerator(RocketPunchPropertiesConfig config) {
+        return new RocketPunchQueryParamGenerator(config);
+    }
+}

--- a/src/main/java/flab/project/jobfinder/config/RocketPunchPropertiesConfig.java
+++ b/src/main/java/flab/project/jobfinder/config/RocketPunchPropertiesConfig.java
@@ -1,18 +1,9 @@
 package flab.project.jobfinder.config;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-@Getter
-@Setter
 @Configuration
 @ConfigurationProperties(prefix = "rocket-punch")
-public class RocketPunchPropertiesConfig {
-    private String url;
-    private String searchUrl;
-    private String delimiter;
-    private String selector;
-    private String totalPageSelector;
+public class RocketPunchPropertiesConfig extends PropertiesConfig {
 }

--- a/src/main/java/flab/project/jobfinder/config/RocketPunchPropertiesConfig.java
+++ b/src/main/java/flab/project/jobfinder/config/RocketPunchPropertiesConfig.java
@@ -15,5 +15,4 @@ public class RocketPunchPropertiesConfig {
     private String delimiter;
     private String selector;
     private String numSelector;
-    private int maxThreadPool;
 }

--- a/src/main/java/flab/project/jobfinder/config/RocketPunchPropertiesConfig.java
+++ b/src/main/java/flab/project/jobfinder/config/RocketPunchPropertiesConfig.java
@@ -1,0 +1,19 @@
+package flab.project.jobfinder.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "rocket-punch")
+public class RocketPunchPropertiesConfig {
+    private String url;
+    private String searchUrl;
+    private String delimiter;
+    private String selector;
+    private String numSelector;
+    private int maxThreadPool;
+}

--- a/src/main/java/flab/project/jobfinder/config/RocketPunchPropertiesConfig.java
+++ b/src/main/java/flab/project/jobfinder/config/RocketPunchPropertiesConfig.java
@@ -14,5 +14,5 @@ public class RocketPunchPropertiesConfig {
     private String searchUrl;
     private String delimiter;
     private String selector;
-    private String numSelector;
+    private String totalPageSelector;
 }

--- a/src/main/java/flab/project/jobfinder/config/jobkorea/JobKoreaConfig.java
+++ b/src/main/java/flab/project/jobfinder/config/jobkorea/JobKoreaConfig.java
@@ -1,4 +1,4 @@
-package flab.project.jobfinder.config;
+package flab.project.jobfinder.config.jobkorea;
 
 import flab.project.jobfinder.service.crawler.generator.JobKoreaQueryParamGenerator;
 import flab.project.jobfinder.service.crawler.generator.QueryParamGenerator;

--- a/src/main/java/flab/project/jobfinder/config/jobkorea/JobKoreaPropertiesConfig.java
+++ b/src/main/java/flab/project/jobfinder/config/jobkorea/JobKoreaPropertiesConfig.java
@@ -1,5 +1,6 @@
-package flab.project.jobfinder.config;
+package flab.project.jobfinder.config.jobkorea;
 
+import flab.project.jobfinder.config.PropertiesConfig;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 

--- a/src/main/java/flab/project/jobfinder/config/rocketpunch/RocketPunchConfig.java
+++ b/src/main/java/flab/project/jobfinder/config/rocketpunch/RocketPunchConfig.java
@@ -1,4 +1,4 @@
-package flab.project.jobfinder.config;
+package flab.project.jobfinder.config.rocketpunch;
 
 import flab.project.jobfinder.service.crawler.generator.QueryParamGenerator;
 import flab.project.jobfinder.service.crawler.generator.RocketPunchQueryParamGenerator;

--- a/src/main/java/flab/project/jobfinder/config/rocketpunch/RocketPunchPropertiesConfig.java
+++ b/src/main/java/flab/project/jobfinder/config/rocketpunch/RocketPunchPropertiesConfig.java
@@ -1,5 +1,6 @@
-package flab.project.jobfinder.config;
+package flab.project.jobfinder.config.rocketpunch;
 
+import flab.project.jobfinder.config.PropertiesConfig;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 

--- a/src/main/java/flab/project/jobfinder/controller/JobFinderController.java
+++ b/src/main/java/flab/project/jobfinder/controller/JobFinderController.java
@@ -1,9 +1,6 @@
 package flab.project.jobfinder.controller;
 
-import flab.project.jobfinder.dto.DetailedSearchDto;
-import flab.project.jobfinder.dto.RecruitDto;
-import flab.project.jobfinder.dto.RecruitPageDto;
-import flab.project.jobfinder.dto.SearchFormDto;
+import flab.project.jobfinder.dto.*;
 import flab.project.jobfinder.enums.Location;
 import flab.project.jobfinder.enums.Platform;
 import flab.project.jobfinder.service.JobFindFactory;
@@ -52,8 +49,9 @@ public class JobFinderController {
         RecruitPageDto recruitPageDto = jobFindFactory.getRecruitPageDto(detailedSearchDto, currentPage);
 
         List<RecruitDto> recruitDtoList = recruitPageDto.getRecruitDtoList();
-        int totalPage = recruitPageDto.getTotalPage();
-        int startPage = recruitPageDto.getStartPage();
+        PageDto pageDto = recruitPageDto.getPageDto();
+        int totalPage = pageDto.getTotalPage();
+        int startPage = pageDto.getStartPage();
 
         model.addAttribute("recruitDtoList", recruitDtoList);
         model.addAttribute("startPage", startPage);

--- a/src/main/java/flab/project/jobfinder/dto/DetailedSearchDto.java
+++ b/src/main/java/flab/project/jobfinder/dto/DetailedSearchDto.java
@@ -3,7 +3,6 @@ package flab.project.jobfinder.dto;
 import flab.project.jobfinder.enums.*;
 import lombok.*;
 
-import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @Builder

--- a/src/main/java/flab/project/jobfinder/dto/PageDto.java
+++ b/src/main/java/flab/project/jobfinder/dto/PageDto.java
@@ -1,0 +1,11 @@
+package flab.project.jobfinder.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PageDto {
+    private int totalPage;
+    private int startPage;
+}

--- a/src/main/java/flab/project/jobfinder/dto/RecruitPageDto.java
+++ b/src/main/java/flab/project/jobfinder/dto/RecruitPageDto.java
@@ -11,6 +11,5 @@ import java.util.List;
 @AllArgsConstructor
 public class RecruitPageDto {
     private List<RecruitDto> recruitDtoList;
-    private int totalPage;
-    private int startPage;
+    private PageDto pageDto;
 }

--- a/src/main/java/flab/project/jobfinder/enums/CareerType.java
+++ b/src/main/java/flab/project/jobfinder/enums/CareerType.java
@@ -1,17 +1,23 @@
 package flab.project.jobfinder.enums;
 
 public enum CareerType {
-    JUNIOR("1"),
-    SENIOR("2"),
-    ANY("4");
+    JUNIOR("1", "1"),
+    SENIOR("2", "2"),
+    ANY("4", "3");
 
     private final String jobkoreaCode;
+    private final String rocketPunchCode;
 
-    CareerType(String jobkoreaCode) {
+    CareerType(String jobkoreaCode, String rocketPunchCode) {
         this.jobkoreaCode = jobkoreaCode;
+        this.rocketPunchCode = rocketPunchCode;
     }
 
     public String jobkoreaCode() {
         return jobkoreaCode;
+    }
+
+    public String rocketPunchCode() {
+        return rocketPunchCode;
     }
 }

--- a/src/main/java/flab/project/jobfinder/enums/JobType.java
+++ b/src/main/java/flab/project/jobfinder/enums/JobType.java
@@ -1,19 +1,25 @@
 package flab.project.jobfinder.enums;
 
 public enum JobType {
-    FULL_TIME("1"),
-    TEMPORARY("2"),
-    INTERN("3"),
-    FREELANCER("6"),
-    MILITARY("9");
+    FULL_TIME("1", "0"),
+    TEMPORARY("2", "1"),
+    INTERN("3", "4"),
+    FREELANCER("6", "2"),
+    MILITARY("9", "3");
 
     private final String jobkoreaCode;
+    private final String rocketPunchCode;
 
-    JobType(String jobkoreaCode) {
+    JobType(String jobkoreaCode, String rocketPunchCode) {
         this.jobkoreaCode = jobkoreaCode;
+        this.rocketPunchCode = rocketPunchCode;
     }
 
     public String jobkoreaCode() {
         return jobkoreaCode;
+    }
+
+    public String rocketPunchCode() {
+        return rocketPunchCode;
     }
 }

--- a/src/main/java/flab/project/jobfinder/enums/Location.java
+++ b/src/main/java/flab/project/jobfinder/enums/Location.java
@@ -5,66 +5,73 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public enum Location {
-    SEOUL("서울", "I000"),
-    GANGNAM("강남구", "I010"),
-    GANGDONG("강동구", "I020"),
-    GANGBUK("강북구", "I030"),
-    GANGSEO("강서구", "I040"),
-    GWANAK("관악구", "I050"),
-    GWANGJIN("광진구", "I060"),
-    GURO("구로구", "I070"),
-    GEUMCHEON("금천구", "I080"),
-    NOWON("노원구", "I090"),
-    DOBONG("도봉구", "I100"),
-    DONGDAEMUN("동대문구", "I110"),
-    DONGJAK("동작구", "I120"),
-    MAPO("마포구", "I130"),
-    SEODAEMUN("서대문구", "I140"),
-    SEOCHO("서초구", "I150"),
-    SEODONG("성동구", "I160"),
-    SEONGBUK("성북구", "I170"),
-    SONGPA("송파구", "I180"),
-    YANGCHEON("양천구", "I190"),
-    YEONGDEUNGPO("영등포구", "I200"),
-    YONGSAN("용산구", "I210"),
-    EUNPYEONG("은평구", "I220"),
-    JONGNO("종로구", "I230"),
-    JUNG("중구", "I240"),
-    JUNGRANG("중랑구", "I250"),
-    GYEONGGI("경기", "B000"),
-    BUNDANG("분당구", "B150"),
-    INCHEON("인천", "K000"),
-    DAEJEON("대전", "G000"),
-    SEJONG("세종", "1000"),
-    CHUNGNAM("충남", "O000"),
-    CHUNGBUK("충북", "P000"),
-    GWANGJU("광주", "E000"),
-    JEONNAM("전남", "L000"),
-    JEONBUK("전북", "M000"),
-    DAEGU("대구", "F000"),
-    GYEONGBUK("경북", "D000"),
-    BUSAN("부산", "H000"),
-    ULSAN("울산", "J000"),
-    GYEONGNAM("경남", "C000"),
-    GANGWON("강원", "A000"),
-    JEJU("제주", "N000");
+    SEOUL("서울", "I000", "서울특별시"),
+    GANGNAM("강남구", "I010", "강남구"),
+    GANGDONG("강동구", "I020", "강동구"),
+    GANGBUK("강북구", "I030", "강북구"),
+    GANGSEO("강서구", "I040", "강서구"),
+    GWANAK("관악구", "I050", "관악구"),
+    GWANGJIN("광진구", "I060", "광진구"),
+    GURO("구로구", "I070", "구로구"),
+    GEUMCHEON("금천구", "I080", "금천구"),
+    NOWON("노원구", "I090", "노원구"),
+    DOBONG("도봉구", "I100", "도봉구"),
+    DONGDAEMUN("동대문구", "I110", "동대문구"),
+    DONGJAK("동작구", "I120", "동작구"),
+    MAPO("마포구", "I130", "마포구"),
+    SEODAEMUN("서대문구", "I140", "서대문구"),
+    SEOCHO("서초구", "I150", "서초구"),
+    SEODONG("성동구", "I160", "성동구"),
+    SEONGBUK("성북구", "I170", "성북구"),
+    SONGPA("송파구", "I180", "송파구"),
+    YANGCHEON("양천구", "I190", "양천구"),
+    YEONGDEUNGPO("영등포구", "I200", "영등포구"),
+    YONGSAN("용산구", "I210", "용산구"),
+    EUNPYEONG("은평구", "I220", "은평구"),
+    JONGNO("종로구", "I230", "종로구"),
+    JUNG("중구", "I240", "중구"),
+    JUNGRANG("중랑구", "I250", "중랑구"),
+    GYEONGGI("경기", "B000", "경기도"),
+    BUNDANG("분당구", "B150", "분당구"),
+    INCHEON("인천", "K000", "인천"),
+    DAEJEON("대전", "G000", "대전"),
+    SEJONG("세종", "1000", "세종"),
+    CHUNGNAM("충남", "O000", "충청남도"),
+    CHUNGBUK("충북", "P000", "충청북도"),
+    GWANGJU("광주", "E000", "광주"),
+    JEONNAM("전남", "L000", "전라남도"),
+    JEONBUK("전북", "M000", "전라북도"),
+    DAEGU("대구", "F000", "대구"),
+    GYEONGBUK("경북", "D000",  "경상북도"),
+    BUSAN("부산", "H000", "부산"),
+    ULSAN("울산", "J000", "울산"),
+    GYEONGNAM("경남", "C000", "경상남도"),
+    GANGWON("강원", "A000", "강원도"),
+    JEJU("제주", "N000", "제주도");
 
     private final String district;
-    private final String jobkoreaCode;
+    private final String jobKoreaCode;
+    private final String rocketPunchCode;
+
     private final static Map<String, String> map = Stream.of(values())
             .collect(Collectors.toUnmodifiableMap(Location::district, Location::name));
 
-    Location(String district, String jobkoreaCode) {
+    Location(String district, String jobKoreaCode, String rocketPunchCode) {
         this.district = district;
-        this.jobkoreaCode = jobkoreaCode;
+        this.jobKoreaCode = jobKoreaCode;
+        this.rocketPunchCode = rocketPunchCode;
     }
 
     public String district() {
         return district;
     }
 
-    public String jobkoreaCode() {
-        return jobkoreaCode;
+    public String jobKoreaCode() {
+        return jobKoreaCode;
+    }
+
+    public String rocketPunchCode() {
+        return rocketPunchCode;
     }
 
     public static Map<String, String> getDistrictMap() {

--- a/src/main/java/flab/project/jobfinder/enums/Platform.java
+++ b/src/main/java/flab/project/jobfinder/enums/Platform.java
@@ -5,7 +5,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public enum Platform {
-    JOBKOREA("잡코리아");
+    JOBKOREA("잡코리아"),
+    ROCKETPUNCH("로켓펀치");
 
     private final String koreaName;
     private final static Map<String, String> map = Stream.of(values())

--- a/src/main/java/flab/project/jobfinder/service/JobKoreaJobFindService.java
+++ b/src/main/java/flab/project/jobfinder/service/JobKoreaJobFindService.java
@@ -2,6 +2,7 @@ package flab.project.jobfinder.service;
 
 import flab.project.jobfinder.config.jobkorea.JobKoreaPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
+import flab.project.jobfinder.dto.PageDto;
 import flab.project.jobfinder.dto.RecruitDto;
 import flab.project.jobfinder.dto.RecruitPageDto;
 import flab.project.jobfinder.enums.Platform;
@@ -34,12 +35,16 @@ public class JobKoreaJobFindService implements JobFindService {
         int startPage = jobKoreaPaginationParser.getStartPage(page);
         List<RecruitDto> recruitDtoList = parsePage(doc);
 
+        PageDto pageDto = PageDto.builder()
+                .startPage(startPage)
+                .totalPage(totalPage)
+                .build();
+
         log.info("total page: {}", totalPage);
 
         return RecruitPageDto.builder()
                 .recruitDtoList(recruitDtoList)
-                .totalPage(totalPage)
-                .startPage(startPage)
+                .pageDto(pageDto)
                 .build();
     }
 

--- a/src/main/java/flab/project/jobfinder/service/JobKoreaJobFindService.java
+++ b/src/main/java/flab/project/jobfinder/service/JobKoreaJobFindService.java
@@ -1,6 +1,6 @@
 package flab.project.jobfinder.service;
 
-import flab.project.jobfinder.config.JobKoreaPropertiesConfig;
+import flab.project.jobfinder.config.jobkorea.JobKoreaPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.dto.RecruitDto;
 import flab.project.jobfinder.dto.RecruitPageDto;

--- a/src/main/java/flab/project/jobfinder/service/JobKoreaJobFindService.java
+++ b/src/main/java/flab/project/jobfinder/service/JobKoreaJobFindService.java
@@ -8,6 +8,7 @@ import flab.project.jobfinder.enums.Platform;
 import flab.project.jobfinder.exception.CrawlFailedException;
 import flab.project.jobfinder.service.crawler.CrawlerService;
 import flab.project.jobfinder.service.parser.ParserService;
+import flab.project.jobfinder.service.parser.pagination.PaginationParser;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.nodes.Document;
@@ -23,16 +24,14 @@ public class JobKoreaJobFindService implements JobFindService {
 
     private final CrawlerService jobKoreaCrawlerService;
     private final ParserService jobKoreaParserService;
+    private final PaginationParser jobKoreaPaginationParser;
     private final JobKoreaPropertiesConfig config;
-
-    private final static int RECRUIT_COUNT_PER_PAGE = 20;
-    private final static int MIDDLE_OF_PAGES = 4;
-    private final static int FIRST_PAGE = 1;
 
     @Override
     public RecruitPageDto findJobByPage(DetailedSearchDto dto, int page) throws CrawlFailedException {
         Document doc = jobKoreaCrawlerService.crawl(dto, page);
-        int totalPage = getTotalPage(doc);
+        int totalPage = jobKoreaPaginationParser.getTotalPage(doc, config);
+        int startPage = jobKoreaPaginationParser.getStartPage(page);
         List<RecruitDto> recruitDtoList = parsePage(doc);
 
         log.info("total page: {}", totalPage);
@@ -40,39 +39,17 @@ public class JobKoreaJobFindService implements JobFindService {
         return RecruitPageDto.builder()
                 .recruitDtoList(recruitDtoList)
                 .totalPage(totalPage)
-                .startPage(getStartPage(page))
+                .startPage(startPage)
                 .build();
-    }
-
-    @Override
-    public Platform getPlatform() {
-        return Platform.JOBKOREA;
-    }
-
-    private int getStartPage(int currentPage) {
-        //1, 2, 3, 4 페이지일 때는 startPage = 1
-        if (currentPage <= MIDDLE_OF_PAGES) {
-            return FIRST_PAGE;
-        }
-        return currentPage - MIDDLE_OF_PAGES;
-    }
-
-    private int getTotalPage(Document doc) {
-        int pageNum = getPageNum(doc);
-        //page가 1부터 시작하므로 1 더해줌
-        return pageNum / RECRUIT_COUNT_PER_PAGE + 1;
-    }
-
-    private int getPageNum(Document doc) {
-        String numSelector = config.getNumSelector();
-        String pageNumStr = doc.select(numSelector)
-                                .text()
-                                .replaceAll("[^0-9]", "");
-        return Integer.parseInt(pageNumStr);
     }
 
     private List<RecruitDto> parsePage(Document pageDoc) {
         Elements recruits = pageDoc.select(config.getSelector());
         return jobKoreaParserService.parse(recruits);
+    }
+
+    @Override
+    public Platform getPlatform() {
+        return Platform.JOBKOREA;
     }
 }

--- a/src/main/java/flab/project/jobfinder/service/RocketPunchJobFindService.java
+++ b/src/main/java/flab/project/jobfinder/service/RocketPunchJobFindService.java
@@ -1,6 +1,6 @@
 package flab.project.jobfinder.service;
 
-import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
+import flab.project.jobfinder.config.rocketpunch.RocketPunchPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.dto.RecruitDto;
 import flab.project.jobfinder.dto.RecruitPageDto;

--- a/src/main/java/flab/project/jobfinder/service/RocketPunchJobFindService.java
+++ b/src/main/java/flab/project/jobfinder/service/RocketPunchJobFindService.java
@@ -25,7 +25,6 @@ public class RocketPunchJobFindService implements JobFindService {
     private final ParserService rocketPunchParserService;
     private final RocketPunchPropertiesConfig config;
 
-    private final static int RECRUIT_COUNT_PER_PAGE = 20;
     private final static int MIDDLE_OF_PAGES = 4;
     private final static int FIRST_PAGE = 1;
 
@@ -44,6 +43,11 @@ public class RocketPunchJobFindService implements JobFindService {
                 .build();
     }
 
+    private List<RecruitDto> parsePage(Document pageDoc) {
+        Elements recruits = pageDoc.select(config.getSelector());
+        return rocketPunchParserService.parse(recruits);
+    }
+
     @Override
     public Platform getPlatform() {
         return Platform.ROCKETPUNCH;
@@ -58,21 +62,13 @@ public class RocketPunchJobFindService implements JobFindService {
     }
 
     private int getTotalPage(Document doc) {
-        int pageNum = getPageNum(doc);
-        //page가 1부터 시작하므로 1 더해줌
-        return pageNum / RECRUIT_COUNT_PER_PAGE + 1;
-    }
+        String totalPageSelector = config.getTotalPageSelector();
 
-    private int getPageNum(Document doc) {
-        String numSelector = config.getNumSelector();
-        String pageNumStr = doc.select(numSelector)
-                                .text()
-                                .replaceAll("[^0-9]", "");
-        return Integer.parseInt(pageNumStr);
-    }
-
-    private List<RecruitDto> parsePage(Document pageDoc) {
-        Elements recruits = pageDoc.select(config.getSelector());
-        return rocketPunchParserService.parse(recruits);
+        Elements select = doc.select(totalPageSelector);
+        if (select.size() == 0) {
+            return 1;
+        }
+        String totalPageStr = select.last().text();
+        return Integer.parseInt(totalPageStr);
     }
 }

--- a/src/main/java/flab/project/jobfinder/service/RocketPunchJobFindService.java
+++ b/src/main/java/flab/project/jobfinder/service/RocketPunchJobFindService.java
@@ -8,6 +8,7 @@ import flab.project.jobfinder.enums.Platform;
 import flab.project.jobfinder.exception.CrawlFailedException;
 import flab.project.jobfinder.service.crawler.CrawlerService;
 import flab.project.jobfinder.service.parser.ParserService;
+import flab.project.jobfinder.service.parser.pagination.PaginationParser;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.nodes.Document;
@@ -23,15 +24,14 @@ public class RocketPunchJobFindService implements JobFindService {
 
     private final CrawlerService rocketPunchCrawlerService;
     private final ParserService rocketPunchParserService;
+    private final PaginationParser rocketPunchPaginationParser;
     private final RocketPunchPropertiesConfig config;
-
-    private final static int MIDDLE_OF_PAGES = 4;
-    private final static int FIRST_PAGE = 1;
 
     @Override
     public RecruitPageDto findJobByPage(DetailedSearchDto dto, int page) throws CrawlFailedException {
         Document doc = rocketPunchCrawlerService.crawl(dto, page);
-        int totalPage = getTotalPage(doc);
+        int totalPage = rocketPunchPaginationParser.getTotalPage(doc, config);
+        int startPage = rocketPunchPaginationParser.getStartPage(page);
         List<RecruitDto> recruitDtoList = parsePage(doc);
 
         log.info("total page: {}", totalPage);
@@ -39,7 +39,7 @@ public class RocketPunchJobFindService implements JobFindService {
         return RecruitPageDto.builder()
                 .recruitDtoList(recruitDtoList)
                 .totalPage(totalPage)
-                .startPage(getStartPage(page))
+                .startPage(startPage)
                 .build();
     }
 
@@ -51,24 +51,5 @@ public class RocketPunchJobFindService implements JobFindService {
     @Override
     public Platform getPlatform() {
         return Platform.ROCKETPUNCH;
-    }
-
-    private int getStartPage(int currentPage) {
-        //1, 2, 3, 4 페이지일 때는 startPage = 1
-        if (currentPage <= MIDDLE_OF_PAGES) {
-            return FIRST_PAGE;
-        }
-        return currentPage - MIDDLE_OF_PAGES;
-    }
-
-    private int getTotalPage(Document doc) {
-        String totalPageSelector = config.getTotalPageSelector();
-
-        Elements select = doc.select(totalPageSelector);
-        if (select.size() == 0) {
-            return 1;
-        }
-        String totalPageStr = select.last().text();
-        return Integer.parseInt(totalPageStr);
     }
 }

--- a/src/main/java/flab/project/jobfinder/service/RocketPunchJobFindService.java
+++ b/src/main/java/flab/project/jobfinder/service/RocketPunchJobFindService.java
@@ -2,6 +2,7 @@ package flab.project.jobfinder.service;
 
 import flab.project.jobfinder.config.rocketpunch.RocketPunchPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
+import flab.project.jobfinder.dto.PageDto;
 import flab.project.jobfinder.dto.RecruitDto;
 import flab.project.jobfinder.dto.RecruitPageDto;
 import flab.project.jobfinder.enums.Platform;
@@ -34,12 +35,16 @@ public class RocketPunchJobFindService implements JobFindService {
         int startPage = rocketPunchPaginationParser.getStartPage(page);
         List<RecruitDto> recruitDtoList = parsePage(doc);
 
+        PageDto pageDto = PageDto.builder()
+                .startPage(startPage)
+                .totalPage(totalPage)
+                .build();
+
         log.info("total page: {}", totalPage);
 
         return RecruitPageDto.builder()
                 .recruitDtoList(recruitDtoList)
-                .totalPage(totalPage)
-                .startPage(startPage)
+                .pageDto(pageDto)
                 .build();
     }
 

--- a/src/main/java/flab/project/jobfinder/service/RocketPunchJobFindService.java
+++ b/src/main/java/flab/project/jobfinder/service/RocketPunchJobFindService.java
@@ -1,0 +1,78 @@
+package flab.project.jobfinder.service;
+
+import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
+import flab.project.jobfinder.dto.DetailedSearchDto;
+import flab.project.jobfinder.dto.RecruitDto;
+import flab.project.jobfinder.dto.RecruitPageDto;
+import flab.project.jobfinder.enums.Platform;
+import flab.project.jobfinder.exception.CrawlFailedException;
+import flab.project.jobfinder.service.crawler.CrawlerService;
+import flab.project.jobfinder.service.parser.ParserService;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class RocketPunchJobFindService implements JobFindService {
+
+    private final CrawlerService rocketPunchCrawlerService;
+    private final ParserService rocketPunchParserService;
+    private final RocketPunchPropertiesConfig config;
+
+    private final static int RECRUIT_COUNT_PER_PAGE = 20;
+    private final static int MIDDLE_OF_PAGES = 4;
+    private final static int FIRST_PAGE = 1;
+
+    @Override
+    public RecruitPageDto findJobByPage(DetailedSearchDto dto, int page) throws CrawlFailedException {
+        Document doc = rocketPunchCrawlerService.crawl(dto, page);
+        int totalPage = getTotalPage(doc);
+        List<RecruitDto> recruitDtoList = parsePage(doc);
+
+        log.info("total page: {}", totalPage);
+
+        return RecruitPageDto.builder()
+                .recruitDtoList(recruitDtoList)
+                .totalPage(totalPage)
+                .startPage(getStartPage(page))
+                .build();
+    }
+
+    @Override
+    public Platform getPlatform() {
+        return Platform.ROCKETPUNCH;
+    }
+
+    private int getStartPage(int currentPage) {
+        //1, 2, 3, 4 페이지일 때는 startPage = 1
+        if (currentPage <= MIDDLE_OF_PAGES) {
+            return FIRST_PAGE;
+        }
+        return currentPage - MIDDLE_OF_PAGES;
+    }
+
+    private int getTotalPage(Document doc) {
+        int pageNum = getPageNum(doc);
+        //page가 1부터 시작하므로 1 더해줌
+        return pageNum / RECRUIT_COUNT_PER_PAGE + 1;
+    }
+
+    private int getPageNum(Document doc) {
+        String numSelector = config.getNumSelector();
+        String pageNumStr = doc.select(numSelector)
+                                .text()
+                                .replaceAll("[^0-9]", "");
+        return Integer.parseInt(pageNumStr);
+    }
+
+    private List<RecruitDto> parsePage(Document pageDoc) {
+        Elements recruits = pageDoc.select(config.getSelector());
+        return rocketPunchParserService.parse(recruits);
+    }
+}

--- a/src/main/java/flab/project/jobfinder/service/crawler/JobKoreaCrawlerService.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/JobKoreaCrawlerService.java
@@ -1,6 +1,6 @@
 package flab.project.jobfinder.service.crawler;
 
-import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
+import flab.project.jobfinder.config.JobKoreaPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.exception.CrawlFailedException;
 import flab.project.jobfinder.service.crawler.generator.QueryParamGenerator;
@@ -18,10 +18,10 @@ import java.io.IOException;
 public class JobKoreaCrawlerService implements CrawlerService {
 
     private final QueryParamGenerator paramGenerator;
-    private final RocketPunchPropertiesConfig config;
+    private final JobKoreaPropertiesConfig config;
 
     @Autowired
-    public JobKoreaCrawlerService(@Qualifier("rocketPunchQueryParamGenerator") QueryParamGenerator paramGenerator, RocketPunchPropertiesConfig config) {
+    public JobKoreaCrawlerService(@Qualifier("jobKoreaQueryParamGenerator") QueryParamGenerator paramGenerator, JobKoreaPropertiesConfig config) {
         this.paramGenerator = paramGenerator;
         this.config = config;
     }

--- a/src/main/java/flab/project/jobfinder/service/crawler/JobKoreaCrawlerService.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/JobKoreaCrawlerService.java
@@ -5,6 +5,7 @@ import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.exception.CrawlFailedException;
 import flab.project.jobfinder.service.crawler.generator.QueryParamGenerator;
 import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -28,13 +30,16 @@ public class JobKoreaCrawlerService implements CrawlerService {
 
     @Override
     public Document crawl(DetailedSearchDto dto, int pageNum) {
-        String url = config.getSearchUrl() + paramGenerator.toQueryParams(dto, pageNum);
+        String url = config.getSearchUrl();
+        Map<String, String> map = paramGenerator.toQueryParams(dto, pageNum).toSingleValueMap();
 
-        log.info("parsing url = {}", url);
         try {
-            Document doc = Jsoup.connect(url).get();
-
-            return doc;
+            log.info("url = {}", url);
+            log.info("queryParam = {}", map);
+            return  Jsoup.connect(url)
+                    .data(map)
+                    .timeout(5000)
+                    .get();
         } catch (IOException e) {
             log.error(e.getMessage());
             throw new CrawlFailedException("서버 연결에 실패했습니다.");

--- a/src/main/java/flab/project/jobfinder/service/crawler/JobKoreaCrawlerService.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/JobKoreaCrawlerService.java
@@ -30,7 +30,7 @@ public class JobKoreaCrawlerService implements CrawlerService {
     @Override
     public Document crawl(DetailedSearchDto dto, int pageNum) {
         String url = config.getSearchUrl();
-        Map<String, String> queryParams = paramGenerator.toQueryParams(dto, pageNum).toSingleValueMap();
+        final Map<String, String> queryParams = paramGenerator.toQueryParams(dto, pageNum).toSingleValueMap();
 
         try {
             log.info("url = {}", url);

--- a/src/main/java/flab/project/jobfinder/service/crawler/JobKoreaCrawlerService.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/JobKoreaCrawlerService.java
@@ -31,13 +31,13 @@ public class JobKoreaCrawlerService implements CrawlerService {
     @Override
     public Document crawl(DetailedSearchDto dto, int pageNum) {
         String url = config.getSearchUrl();
-        Map<String, String> map = paramGenerator.toQueryParams(dto, pageNum).toSingleValueMap();
+        Map<String, String> queryParams = paramGenerator.toQueryParams(dto, pageNum).toSingleValueMap();
 
         try {
             log.info("url = {}", url);
-            log.info("queryParam = {}", map);
+            log.info("queryParam = {}", queryParams);
             return  Jsoup.connect(url)
-                    .data(map)
+                    .data(queryParams)
                     .timeout(5000)
                     .get();
         } catch (IOException e) {

--- a/src/main/java/flab/project/jobfinder/service/crawler/JobKoreaCrawlerService.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/JobKoreaCrawlerService.java
@@ -1,11 +1,10 @@
 package flab.project.jobfinder.service.crawler;
 
-import flab.project.jobfinder.config.JobKoreaPropertiesConfig;
+import flab.project.jobfinder.config.jobkorea.JobKoreaPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.exception.CrawlFailedException;
 import flab.project.jobfinder.service.crawler.generator.QueryParamGenerator;
 import lombok.extern.slf4j.Slf4j;
-import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerService.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerService.java
@@ -1,6 +1,6 @@
 package flab.project.jobfinder.service.crawler;
 
-import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
+import flab.project.jobfinder.config.JobKoreaPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.exception.CrawlFailedException;
 import flab.project.jobfinder.service.crawler.generator.QueryParamGenerator;
@@ -15,13 +15,13 @@ import java.io.IOException;
 
 @Slf4j
 @Service
-public class JobKoreaCrawlerService implements CrawlerService {
+public class RocketPunchCrawlerService implements CrawlerService {
 
     private final QueryParamGenerator paramGenerator;
-    private final RocketPunchPropertiesConfig config;
+    private final JobKoreaPropertiesConfig config;
 
     @Autowired
-    public JobKoreaCrawlerService(@Qualifier("rocketPunchQueryParamGenerator") QueryParamGenerator paramGenerator, RocketPunchPropertiesConfig config) {
+    public RocketPunchCrawlerService(@Qualifier("rocketPunchQueryParamGenerator") QueryParamGenerator paramGenerator, JobKoreaPropertiesConfig config) {
         this.paramGenerator = paramGenerator;
         this.config = config;
     }

--- a/src/main/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerService.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerService.java
@@ -4,40 +4,70 @@ import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.exception.CrawlFailedException;
 import flab.project.jobfinder.service.crawler.generator.QueryParamGenerator;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
 
-import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class RocketPunchCrawlerService implements CrawlerService {
 
-    private final QueryParamGenerator paramGenerator;
+    private final QueryParamGenerator rocketPunchQueryParamGenerator;
     private final RocketPunchPropertiesConfig config;
-
-    @Autowired
-    public RocketPunchCrawlerService(@Qualifier("rocketPunchQueryParamGenerator") QueryParamGenerator paramGenerator, RocketPunchPropertiesConfig config) {
-        this.paramGenerator = paramGenerator;
-        this.config = config;
-    }
+    private final WebClient webClient;
 
     @Override
     public Document crawl(DetailedSearchDto dto, int pageNum) {
-        String url = config.getSearchUrl() + paramGenerator.toQueryParams(dto, pageNum);
+        URI uri = makeUri(dto, pageNum);
 
-        log.info("parsing url = {}", url);
         try {
-            Document doc = Jsoup.connect(url).get();
-
-            return doc;
-        } catch (IOException e) {
+            String htmlTemplate = webClient
+                    .get()
+                    .uri(uri)
+                    .retrieve()
+                    .bodyToMono(RocketPunchResponseDto.class)
+                    .block()
+                    .getData()
+                    .getTemplate();
+            return Jsoup.parse(htmlTemplate);
+        } catch (NullPointerException e) {
             log.error(e.getMessage());
             throw new CrawlFailedException("서버 연결에 실패했습니다.");
+        }
+    }
+
+    private URI makeUri(DetailedSearchDto dto, int pageNum) {
+        String url = config.getSearchUrl();
+        Set<Map.Entry<String, List<String>>> queryParams = rocketPunchQueryParamGenerator
+                                                            .toQueryParams(dto, pageNum)
+                                                            .entrySet();
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(url);
+
+        log.info("url = {}", url);
+        log.info("queryParams = {}", queryParams);
+
+        queryParams.forEach(entry -> entry.getValue()
+                    .forEach(param -> uriBuilder.queryParam(entry.getKey(), param)));
+        return uriBuilder.build().encode().toUri();
+    }
+
+    @Data
+    static class RocketPunchResponseDto {
+        private Content data;
+
+        @Data
+        static class Content {
+            private String template;
         }
     }
 }

--- a/src/main/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerService.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerService.java
@@ -1,6 +1,6 @@
 package flab.project.jobfinder.service.crawler;
 
-import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
+import flab.project.jobfinder.config.rocketpunch.RocketPunchPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.exception.CrawlFailedException;
 import flab.project.jobfinder.service.crawler.generator.QueryParamGenerator;
@@ -13,9 +13,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 @Slf4j
 @Service

--- a/src/main/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerService.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerService.java
@@ -48,16 +48,13 @@ public class RocketPunchCrawlerService implements CrawlerService {
 
     private URI makeUri(DetailedSearchDto dto, int pageNum) {
         String url = config.getSearchUrl();
-        Set<Map.Entry<String, List<String>>> queryParams = rocketPunchQueryParamGenerator
-                                                            .toQueryParams(dto, pageNum)
-                                                            .entrySet();
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(url);
+        rocketPunchQueryParamGenerator.toQueryParams(dto, pageNum)
+                                        .forEach((key, value) -> value
+                                                .forEach(param -> uriBuilder.queryParam(key, param)));
 
         log.info("url = {}", url);
-        log.info("queryParams = {}", queryParams);
 
-        queryParams.forEach(entry -> entry.getValue()
-                    .forEach(param -> uriBuilder.queryParam(entry.getKey(), param)));
         return uriBuilder.build().encode().toUri();
     }
 

--- a/src/main/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerService.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerService.java
@@ -1,6 +1,6 @@
 package flab.project.jobfinder.service.crawler;
 
-import flab.project.jobfinder.config.JobKoreaPropertiesConfig;
+import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.exception.CrawlFailedException;
 import flab.project.jobfinder.service.crawler.generator.QueryParamGenerator;
@@ -18,10 +18,10 @@ import java.io.IOException;
 public class RocketPunchCrawlerService implements CrawlerService {
 
     private final QueryParamGenerator paramGenerator;
-    private final JobKoreaPropertiesConfig config;
+    private final RocketPunchPropertiesConfig config;
 
     @Autowired
-    public RocketPunchCrawlerService(@Qualifier("rocketPunchQueryParamGenerator") QueryParamGenerator paramGenerator, JobKoreaPropertiesConfig config) {
+    public RocketPunchCrawlerService(@Qualifier("rocketPunchQueryParamGenerator") QueryParamGenerator paramGenerator, RocketPunchPropertiesConfig config) {
         this.paramGenerator = paramGenerator;
         this.config = config;
     }

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/JobKoreaQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/JobKoreaQueryParamGenerator.java
@@ -28,17 +28,17 @@ public class JobKoreaQueryParamGenerator implements QueryParamGenerator {
 
     @Override
     public MultiValueMap<String, String> toQueryParams(DetailedSearchDto dto, int pageNum) {
-        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-        map.add(TAB_TYPE_KEY, "recruit");
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add(TAB_TYPE_KEY, "recruit");
 
-        Optional.ofNullable(dto.getSearchText()).ifPresent(searchText -> map.add(SEARCH_TEXT_KEY, searchText));
-        Optional.ofNullable(dto.getLocation()).ifPresent(locations -> map.addAll(LOCATION_KEY, toLocationParam(locations)));
-        Optional.ofNullable(dto.getCareer()).ifPresent(career -> map.addAll(toCareerParam(career)));
-        Optional.ofNullable(dto.getJobType()).ifPresent(jobTypes -> map.addAll(JOB_TYPE_KEY, toJobTypeParam(jobTypes)));
-        Optional.ofNullable(dto.getPay()).ifPresent(pay -> map.addAll(toPayParam(pay)));
-        map.add(PAGE_KEY, String.valueOf(pageNum));
+        Optional.ofNullable(dto.getSearchText()).ifPresent(searchText -> queryParams.add(SEARCH_TEXT_KEY, searchText));
+        Optional.ofNullable(dto.getLocation()).ifPresent(locations -> queryParams.addAll(LOCATION_KEY, toLocationParam(locations)));
+        Optional.ofNullable(dto.getCareer()).ifPresent(career -> queryParams.addAll(toCareerParam(career)));
+        Optional.ofNullable(dto.getJobType()).ifPresent(jobTypes -> queryParams.addAll(JOB_TYPE_KEY, toJobTypeParam(jobTypes)));
+        Optional.ofNullable(dto.getPay()).ifPresent(pay -> queryParams.addAll(toPayParam(pay)));
+        queryParams.add(PAGE_KEY, String.valueOf(pageNum));
 
-        return map;
+        return queryParams;
     }
 
     private List<String> toJobTypeParam(List<JobType> jobTypes) {
@@ -54,26 +54,26 @@ public class JobKoreaQueryParamGenerator implements QueryParamGenerator {
     }
 
     private MultiValueMap<String, String> toCareerParam(DetailedSearchDto.Career career) {
-        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        MultiValueMap<String, String> careerParam = new LinkedMultiValueMap<>();
 
         Optional.ofNullable(career.getCareerType())
-                .ifPresent(careerType -> map.add(CAREER_TYPE_KEY, careerType.jobkoreaCode()));
+                .ifPresent(careerType -> careerParam.add(CAREER_TYPE_KEY, careerType.jobkoreaCode()));
         Optional.ofNullable(career.getCareerMin())
-                .ifPresent(careerMin -> map.add(CAREER_MIN_KEY, careerMin.toString()));
+                .ifPresent(careerMin -> careerParam.add(CAREER_MIN_KEY, careerMin.toString()));
         Optional.ofNullable(career.getCareerMax())
-                .ifPresent(careerMax -> map.add(CAREER_MAX_KEY, careerMax.toString()));
-        return map;
+                .ifPresent(careerMax -> careerParam.add(CAREER_MAX_KEY, careerMax.toString()));
+        return careerParam;
     }
 
     private MultiValueMap<String, String> toPayParam(DetailedSearchDto.Pay pay) {
-        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        MultiValueMap<String, String> payParam = new LinkedMultiValueMap<>();
 
         Optional.ofNullable(pay.getPayType())
-                .ifPresent(payType -> map.add(PAY_TYPE_KEY, payType.jobkoreaCode()));
+                .ifPresent(payType -> payParam.add(PAY_TYPE_KEY, payType.jobkoreaCode()));
         Optional.ofNullable(pay.getPayMin())
-                .ifPresent(payMin -> map.add(PAY_MIN_KEY, payMin.toString()));
+                .ifPresent(payMin -> payParam.add(PAY_MIN_KEY, payMin.toString()));
         Optional.ofNullable(pay.getPayMax())
-                .ifPresent(payMax -> map.add(PAY_MAX_KEY, payMax.toString()));
-        return map;
+                .ifPresent(payMax -> payParam.add(PAY_MAX_KEY, payMax.toString()));
+        return payParam;
     }
 }

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/JobKoreaQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/JobKoreaQueryParamGenerator.java
@@ -58,7 +58,7 @@ public class JobKoreaQueryParamGenerator implements QueryParamGenerator {
             return "";
         }
         String location = locations.stream()
-                .map(Location::jobkoreaCode)
+                .map(Location::jobKoreaCode)
                 .collect(Collectors.joining(config.getDelimiter()));
         return "&local=" + location;
     }

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/JobKoreaQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/JobKoreaQueryParamGenerator.java
@@ -15,11 +15,23 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class JobKoreaQueryParamGenerator implements QueryParamGenerator {
 
+    public static final String SEARCH_TEXT_KEY = "stext";
+    public static final String JOBTYPE_KEY = "jobtype";
+    public static final String LOCATION_KEY = "local";
+    public static final String CAREER_TYPE_KEY = "careerType";
+    public static final String CAREER_MIN_KEY = "careerMin";
+    public static final String CAREER_MAX_KEY = "careerMax";
+    public static final String PAY_TYPE_KEY = "payType";
+    public static final String PAY_MIN_KEY = "payMin";
+    public static final String PAY_MAX_KEY = "payMax";
+    public static final String PAGE_KEY = "Page_No";
+    public static final String TAB_TYPE_KEY = "tabType";
     private final JobKoreaPropertiesConfig config;
 
     @Override
     public String toQueryParams(DetailedSearchDto dto, int pageNum) {
         StringBuilder queryParams = new StringBuilder("tabType=recruit");
+        StringBuilder queryParams = new StringBuilder(TAB_TYPE_KEY + "=recruit");
         String searchTextParam = Optional.ofNullable(dto.getSearchText()).map(this::toSearchTextParam).orElse("");
         String locationParam = Optional.ofNullable(dto.getLocation()).map(this::toLocationParam).orElse("");
         String careerParam = Optional.ofNullable(dto.getCareer()).map(this::toCareerParam).orElse("");
@@ -40,7 +52,7 @@ public class JobKoreaQueryParamGenerator implements QueryParamGenerator {
     private String toSearchTextParam(String searchText) {
         String encoded = URLEncoder.encode(searchText, StandardCharsets.UTF_8);
 
-        return "&stext=" + encoded;
+        return "&" + SEARCH_TEXT_KEY + "=" + encoded;
     }
 
     private String toJobTypeParam(List<JobType> jobTypes) {
@@ -50,7 +62,7 @@ public class JobKoreaQueryParamGenerator implements QueryParamGenerator {
         String jobType = jobTypes.stream()
                 .map(JobType::jobkoreaCode)
                 .collect(Collectors.joining(config.getDelimiter()));
-        return "&jobtype=" + jobType;
+        return "&" + JOBTYPE_KEY + "=" + jobType;
     }
 
     private String toLocationParam(List<Location> locations) {
@@ -60,18 +72,18 @@ public class JobKoreaQueryParamGenerator implements QueryParamGenerator {
         String location = locations.stream()
                 .map(Location::jobKoreaCode)
                 .collect(Collectors.joining(config.getDelimiter()));
-        return "&local=" + location;
+        return "&" + LOCATION_KEY + "=" + location;
     }
 
     private String toCareerParam(DetailedSearchDto.Career career) {
         StringBuilder params = new StringBuilder();
 
         Optional.ofNullable(career.getCareerType())
-                .ifPresent(careerType -> params.append("&careerType=").append(careerType.jobkoreaCode()));
+                .ifPresent(careerType -> params.append("&" + CAREER_TYPE_KEY + "=").append(careerType.jobkoreaCode()));
         Optional.ofNullable(career.getCareerMin())
-                .ifPresent(careerMin -> params.append("&careerMin=").append(careerMin));
+                .ifPresent(careerMin -> params.append("&" + CAREER_MIN_KEY + "=").append(careerMin));
         Optional.ofNullable(career.getCareerMax())
-                .ifPresent(careerMax -> params.append("&careerMax=").append(careerMax));
+                .ifPresent(careerMax -> params.append("&" + CAREER_MAX_KEY + "=").append(careerMax));
         return params.toString();
     }
 
@@ -79,15 +91,15 @@ public class JobKoreaQueryParamGenerator implements QueryParamGenerator {
         StringBuilder params = new StringBuilder();
 
         Optional.ofNullable(pay.getPayType())
-                .ifPresent(payType -> params.append("&payType=").append(payType.jobkoreaCode()));
+                .ifPresent(payType -> params.append("&" + PAY_TYPE_KEY + "=").append(payType.jobkoreaCode()));
         Optional.ofNullable(pay.getPayMin())
-                .ifPresent(payMin -> params.append("&payMin=").append(payMin));
+                .ifPresent(payMin -> params.append("&" + PAY_MIN_KEY + "=").append(payMin));
         Optional.ofNullable(pay.getPayMax())
-                .ifPresent(payMax -> params.append("&payMax=").append(payMax));
+                .ifPresent(payMax -> params.append("&" + PAY_MAX_KEY + "=").append(payMax));
         return params.toString();
     }
 
     private String toPageNumParam(int pageNum) {
-        return "&Page_No=" + pageNum;
+        return "&" + PAGE_KEY + "=" + pageNum;
     }
 }

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/JobKoreaQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/JobKoreaQueryParamGenerator.java
@@ -1,13 +1,12 @@
 package flab.project.jobfinder.service.crawler.generator;
 
-import flab.project.jobfinder.config.JobKoreaPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.enums.JobType;
 import flab.project.jobfinder.enums.Location;
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -16,7 +15,7 @@ import java.util.stream.Collectors;
 public class JobKoreaQueryParamGenerator implements QueryParamGenerator {
 
     public static final String SEARCH_TEXT_KEY = "stext";
-    public static final String JOBTYPE_KEY = "jobtype";
+    public static final String JOB_TYPE_KEY = "jobtype";
     public static final String LOCATION_KEY = "local";
     public static final String CAREER_TYPE_KEY = "careerType";
     public static final String CAREER_MIN_KEY = "careerMin";
@@ -26,80 +25,55 @@ public class JobKoreaQueryParamGenerator implements QueryParamGenerator {
     public static final String PAY_MAX_KEY = "payMax";
     public static final String PAGE_KEY = "Page_No";
     public static final String TAB_TYPE_KEY = "tabType";
-    private final JobKoreaPropertiesConfig config;
 
     @Override
-    public String toQueryParams(DetailedSearchDto dto, int pageNum) {
-        StringBuilder queryParams = new StringBuilder("tabType=recruit");
-        StringBuilder queryParams = new StringBuilder(TAB_TYPE_KEY + "=recruit");
-        String searchTextParam = Optional.ofNullable(dto.getSearchText()).map(this::toSearchTextParam).orElse("");
-        String locationParam = Optional.ofNullable(dto.getLocation()).map(this::toLocationParam).orElse("");
-        String careerParam = Optional.ofNullable(dto.getCareer()).map(this::toCareerParam).orElse("");
-        String jobParam = Optional.ofNullable(dto.getJobType()).map(this::toJobTypeParam).orElse("");
-        String payParam = Optional.ofNullable(dto.getPay()).map(this::toPayParam).orElse("");
-        String pageNumParam = toPageNumParam(pageNum);
+    public MultiValueMap<String, String> toQueryParams(DetailedSearchDto dto, int pageNum) {
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        map.add(TAB_TYPE_KEY, "recruit");
 
-        queryParams.append(searchTextParam)
-                .append(locationParam)
-                .append(careerParam)
-                .append(jobParam)
-                .append(payParam)
-                .append(pageNumParam);
+        Optional.ofNullable(dto.getSearchText()).ifPresent(searchText -> map.add(SEARCH_TEXT_KEY, searchText));
+        Optional.ofNullable(dto.getLocation()).ifPresent(locations -> map.addAll(LOCATION_KEY, toLocationParam(locations)));
+        Optional.ofNullable(dto.getCareer()).ifPresent(career -> map.addAll(toCareerParam(career)));
+        Optional.ofNullable(dto.getJobType()).ifPresent(jobTypes -> map.addAll(JOB_TYPE_KEY, toJobTypeParam(jobTypes)));
+        Optional.ofNullable(dto.getPay()).ifPresent(pay -> map.addAll(toPayParam(pay)));
+        map.add(PAGE_KEY, String.valueOf(pageNum));
 
-        return queryParams.toString();
+        return map;
     }
 
-    private String toSearchTextParam(String searchText) {
-        String encoded = URLEncoder.encode(searchText, StandardCharsets.UTF_8);
-
-        return "&" + SEARCH_TEXT_KEY + "=" + encoded;
-    }
-
-    private String toJobTypeParam(List<JobType> jobTypes) {
-        if (jobTypes.isEmpty()) {
-            return "";
-        }
-        String jobType = jobTypes.stream()
+    private List<String> toJobTypeParam(List<JobType> jobTypes) {
+        return jobTypes.stream()
                 .map(JobType::jobkoreaCode)
-                .collect(Collectors.joining(config.getDelimiter()));
-        return "&" + JOBTYPE_KEY + "=" + jobType;
+                .collect(Collectors.toList());
     }
 
-    private String toLocationParam(List<Location> locations) {
-        if (locations.isEmpty()) {
-            return "";
-        }
-        String location = locations.stream()
+    private List<String> toLocationParam(List<Location> locations) {
+        return locations.stream()
                 .map(Location::jobKoreaCode)
-                .collect(Collectors.joining(config.getDelimiter()));
-        return "&" + LOCATION_KEY + "=" + location;
+                .collect(Collectors.toList());
     }
 
-    private String toCareerParam(DetailedSearchDto.Career career) {
-        StringBuilder params = new StringBuilder();
+    private MultiValueMap<String, String> toCareerParam(DetailedSearchDto.Career career) {
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
 
         Optional.ofNullable(career.getCareerType())
-                .ifPresent(careerType -> params.append("&" + CAREER_TYPE_KEY + "=").append(careerType.jobkoreaCode()));
+                .ifPresent(careerType -> map.add(CAREER_TYPE_KEY, careerType.jobkoreaCode()));
         Optional.ofNullable(career.getCareerMin())
-                .ifPresent(careerMin -> params.append("&" + CAREER_MIN_KEY + "=").append(careerMin));
+                .ifPresent(careerMin -> map.add(CAREER_MIN_KEY, careerMin.toString()));
         Optional.ofNullable(career.getCareerMax())
-                .ifPresent(careerMax -> params.append("&" + CAREER_MAX_KEY + "=").append(careerMax));
-        return params.toString();
+                .ifPresent(careerMax -> map.add(CAREER_MAX_KEY, careerMax.toString()));
+        return map;
     }
 
-    private String toPayParam(DetailedSearchDto.Pay pay) {
-        StringBuilder params = new StringBuilder();
+    private MultiValueMap<String, String> toPayParam(DetailedSearchDto.Pay pay) {
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
 
         Optional.ofNullable(pay.getPayType())
-                .ifPresent(payType -> params.append("&" + PAY_TYPE_KEY + "=").append(payType.jobkoreaCode()));
+                .ifPresent(payType -> map.add(PAY_TYPE_KEY, payType.jobkoreaCode()));
         Optional.ofNullable(pay.getPayMin())
-                .ifPresent(payMin -> params.append("&" + PAY_MIN_KEY + "=").append(payMin));
+                .ifPresent(payMin -> map.add(PAY_MIN_KEY, payMin.toString()));
         Optional.ofNullable(pay.getPayMax())
-                .ifPresent(payMax -> params.append("&" + PAY_MAX_KEY + "=").append(payMax));
-        return params.toString();
-    }
-
-    private String toPageNumParam(int pageNum) {
-        return "&" + PAGE_KEY + "=" + pageNum;
+                .ifPresent(payMax -> map.add(PAY_MAX_KEY, payMax.toString()));
+        return map;
     }
 }

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/QueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/QueryParamGenerator.java
@@ -1,7 +1,8 @@
 package flab.project.jobfinder.service.crawler.generator;
 
 import flab.project.jobfinder.dto.DetailedSearchDto;
+import org.springframework.util.MultiValueMap;
 
 public interface QueryParamGenerator {
-    String toQueryParams(DetailedSearchDto dto, int pageNum);
+    MultiValueMap<String, String> toQueryParams(DetailedSearchDto dto, int pageNum);
 }

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
@@ -38,7 +38,7 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
     }
 
     private String toSearchTextParam(String searchText) {
-        return "?keywords=" + searchText;
+        return "keywords=" + searchText;
     }
 
     private String toJobTypeParam(List<JobType> jobTypes) {
@@ -77,6 +77,9 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
     private String toPayParam(DetailedSearchDto.Pay pay) {
         StringBuilder params = new StringBuilder("&salary=");
 
+        if (pay.getPayMin() == null && pay.getPayMax() == null) {
+            return "";
+        }
         Integer payMin = Optional.ofNullable(pay.getPayMin()).orElse(0);
         Integer payMax = Optional.ofNullable(pay.getPayMax()).orElse(MAX_PAY);
         params.append(payMin * PAY_UNIT).append("-").append(payMax * PAY_UNIT);

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
@@ -48,7 +48,7 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
         String jobType = jobTypes.stream()
                 .map(JobType::jobkoreaCode)
                 .collect(Collectors.joining(config.getDelimiter()));
-        return "&jobtype=" + jobType;
+        return "&hiring_types=" + jobType;
     }
 
     private String toLocationParam(List<Location> locations) {

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
@@ -6,6 +6,8 @@ import flab.project.jobfinder.enums.JobType;
 import flab.project.jobfinder.enums.Location;
 import lombok.RequiredArgsConstructor;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -46,8 +48,8 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
     }
 
     private String toSearchTextParam(String searchText) {
-        searchText = searchText.replaceAll(" ", "%20");
-        return SEARCH_TEXT_KEY + "=" + searchText;
+        String encoded = URLEncoder.encode(searchText, StandardCharsets.UTF_8);
+        return SEARCH_TEXT_KEY + "=" + encoded;
     }
 
     private String toJobTypeParam(List<JobType> jobTypes) {
@@ -66,6 +68,7 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
         }
         return locations.stream()
                 .map(Location::rocketPunchCode)
+                .map(location -> URLEncoder.encode(location, StandardCharsets.UTF_8))
                 .map(location -> config.getDelimiter() + LOCATION_KEY + "=" + location)
                 .collect(Collectors.joining());
     }

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -34,12 +36,12 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
         Optional.ofNullable(dto.getSearchText())
                 .ifPresent(searchText -> queryParams.add(SEARCH_TEXT_KEY, searchText));
         Optional.ofNullable(dto.getLocation())
-                .ifPresent(locations -> queryParams.add(LOCATION_KEY, toLocationParam(locations)));
+                .ifPresent(locations -> queryParams.addAll(LOCATION_KEY, toLocationParam(locations)));
         Optional.ofNullable(dto.getCareer())
                 .filter(career -> !ANY.equals(career.getCareerType()))
                 .ifPresent(career -> queryParams.add(CAREER_TYPE_KEY, toCareerParam(career)));
         Optional.ofNullable(dto.getJobType())
-                .ifPresent(jobTypes -> queryParams.add(JOB_TYPE_KEY, toJobTypeParam(jobTypes)));
+                .ifPresent(jobTypes -> queryParams.addAll(JOB_TYPE_KEY, toJobTypeParam(jobTypes)));
         Optional.ofNullable(dto.getPay())
                 .filter(pay -> !(pay.getPayMin() == null && pay.getPayMax() == null))
                 .ifPresent(pay -> queryParams.add(PAY_KEY, toPayParam(pay)));
@@ -48,16 +50,16 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
         return queryParams;
     }
 
-    private String toJobTypeParam(List<JobType> jobTypes) {
+    private List<String> toJobTypeParam(List<JobType> jobTypes) {
         return jobTypes.stream()
                 .map(JobType::rocketPunchCode)
-                .collect(Collectors.joining(config.getDelimiter() + JOB_TYPE_KEY + "="));
+                .collect(Collectors.toList());
     }
 
-    private String toLocationParam(List<Location> locations) {
+    private List<String> toLocationParam(List<Location> locations) {
         return locations.stream()
                 .map(Location::rocketPunchCode)
-                .collect(Collectors.joining(config.getDelimiter() + LOCATION_KEY + "="));
+                .collect(Collectors.toList());
     }
 
     private String toCareerParam(DetailedSearchDto.Career career) {

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
@@ -1,0 +1,93 @@
+package flab.project.jobfinder.service.crawler.generator;
+
+import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
+import flab.project.jobfinder.dto.DetailedSearchDto;
+import flab.project.jobfinder.enums.JobType;
+import flab.project.jobfinder.enums.Location;
+import lombok.RequiredArgsConstructor;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
+
+    private final RocketPunchPropertiesConfig config;
+
+    @Override
+    public String toQueryParams(DetailedSearchDto dto, int pageNum) {
+        StringBuilder queryParams = new StringBuilder("tabType=recruit");
+        String searchTextParam = Optional.ofNullable(dto.getSearchText()).map(this::toSearchTextParam).orElse("");
+        String locationParam = Optional.ofNullable(dto.getLocation()).map(this::toLocationParam).orElse("");
+        String careerParam = Optional.ofNullable(dto.getCareer()).map(this::toCareerParam).orElse("");
+        String jobParam = Optional.ofNullable(dto.getJobType()).map(this::toJobTypeParam).orElse("");
+        String payParam = Optional.ofNullable(dto.getPay()).map(this::toPayParam).orElse("");
+        String pageNumParam = toPageNumParam(pageNum);
+
+        queryParams.append(searchTextParam)
+                .append(locationParam)
+                .append(careerParam)
+                .append(jobParam)
+                .append(payParam)
+                .append(pageNumParam);
+
+        return queryParams.toString();
+    }
+
+    private String toSearchTextParam(String searchText) {
+        String encoded = URLEncoder.encode(searchText, StandardCharsets.UTF_8);
+
+        return "&stext=" + encoded;
+    }
+
+    private String toJobTypeParam(List<JobType> jobTypes) {
+        if (jobTypes.isEmpty()) {
+            return "";
+        }
+        String jobType = jobTypes.stream()
+                .map(JobType::jobkoreaCode)
+                .collect(Collectors.joining(config.getDelimiter()));
+        return "&jobtype=" + jobType;
+    }
+
+    private String toLocationParam(List<Location> locations) {
+        if (locations.isEmpty()) {
+            return "";
+        }
+        String location = locations.stream()
+                .map(Location::jobkoreaCode)
+                .collect(Collectors.joining(config.getDelimiter()));
+        return "&local=" + location;
+    }
+
+    private String toCareerParam(DetailedSearchDto.Career career) {
+        StringBuilder params = new StringBuilder();
+
+        Optional.ofNullable(career.getCareerType())
+                .ifPresent(careerType -> params.append("&careerType=").append(careerType.jobkoreaCode()));
+        Optional.ofNullable(career.getCareerMin())
+                .ifPresent(careerMin -> params.append("&careerMin=").append(careerMin));
+        Optional.ofNullable(career.getCareerMax())
+                .ifPresent(careerMax -> params.append("&careerMax=").append(careerMax));
+        return params.toString();
+    }
+
+    private String toPayParam(DetailedSearchDto.Pay pay) {
+        StringBuilder params = new StringBuilder();
+
+        Optional.ofNullable(pay.getPayType())
+                .ifPresent(payType -> params.append("&payType=").append(payType.jobkoreaCode()));
+        Optional.ofNullable(pay.getPayMin())
+                .ifPresent(payMin -> params.append("&payMin=").append(payMin));
+        Optional.ofNullable(pay.getPayMax())
+                .ifPresent(payMax -> params.append("&payMax=").append(payMax));
+        return params.toString();
+    }
+
+    private String toPageNumParam(int pageNum) {
+        return "&Page_No=" + pageNum;
+    }
+}

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
@@ -19,7 +19,7 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
 
     @Override
     public String toQueryParams(DetailedSearchDto dto, int pageNum) {
-        StringBuilder queryParams = new StringBuilder("tabType=recruit");
+        StringBuilder queryParams = new StringBuilder("");
         String searchTextParam = Optional.ofNullable(dto.getSearchText()).map(this::toSearchTextParam).orElse("");
         String locationParam = Optional.ofNullable(dto.getLocation()).map(this::toLocationParam).orElse("");
         String careerParam = Optional.ofNullable(dto.getCareer()).map(this::toCareerParam).orElse("");
@@ -38,9 +38,7 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
     }
 
     private String toSearchTextParam(String searchText) {
-        String encoded = URLEncoder.encode(searchText, StandardCharsets.UTF_8);
-
-        return "&stext=" + encoded;
+        return "?keywords=" + searchText;
     }
 
     private String toJobTypeParam(List<JobType> jobTypes) {
@@ -54,13 +52,14 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
     }
 
     private String toLocationParam(List<Location> locations) {
+        StringBuilder sb = new StringBuilder("");
         if (locations.isEmpty()) {
-            return "";
+            return sb.toString();
         }
-        String location = locations.stream()
-                .map(Location::jobkoreaCode)
-                .collect(Collectors.joining(config.getDelimiter()));
-        return "&local=" + location;
+        locations.stream()
+                .map(Location::rocketPunchCode)
+                .forEach(location -> sb.append("&location=").append(location));
+        return sb.toString();
     }
 
     private String toCareerParam(DetailedSearchDto.Career career) {

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static flab.project.jobfinder.enums.CareerType.ANY;
+import static flab.project.jobfinder.enums.JobType.INTERN;
 
 @RequiredArgsConstructor
 public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
@@ -39,7 +40,7 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
                 .ifPresent(locations -> queryParams.addAll(LOCATION_KEY, toLocationParam(locations)));
         Optional.ofNullable(dto.getCareer())
                 .filter(career -> !ANY.equals(career.getCareerType()))
-                .ifPresent(career -> queryParams.addAll(toCareerParam(career)));
+                .ifPresent(career -> queryParams.addAll(toCareerParam(career, dto.getJobType())));
         Optional.ofNullable(dto.getJobType())
                 .ifPresent(jobTypes -> queryParams.addAll(JOB_TYPE_KEY, toJobTypeParam(jobTypes)));
         Optional.ofNullable(dto.getPay())
@@ -52,8 +53,8 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
 
     private List<String> toJobTypeParam(List<JobType> jobTypes) {
         return jobTypes.stream()
-                .map(JobType::rocketPunchCode)
-                .collect(Collectors.toList());
+                .filter(jobType -> !INTERN.equals(jobType))
+                .map(JobType::rocketPunchCode).toList();
     }
 
     private List<String> toLocationParam(List<Location> locations) {
@@ -62,10 +63,13 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
                 .collect(Collectors.toList());
     }
 
-    private MultiValueMap<String, String> toCareerParam(DetailedSearchDto.Career career) {
+    private MultiValueMap<String, String> toCareerParam(DetailedSearchDto.Career career, List<JobType> jobTypes) {
         MultiValueMap<String, String> careerParam = new LinkedMultiValueMap<>();
         Optional.ofNullable(career.getCareerType())
                 .ifPresent(careerType -> careerParam.add(CAREER_TYPE_KEY, careerType.rocketPunchCode()));
+        if (jobTypes != null && jobTypes.contains(INTERN)) {
+            careerParam.add(CAREER_TYPE_KEY, INTERN.rocketPunchCode());
+        }
         return careerParam;
     }
 

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
@@ -39,7 +39,7 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
                 .ifPresent(locations -> queryParams.addAll(LOCATION_KEY, toLocationParam(locations)));
         Optional.ofNullable(dto.getCareer())
                 .filter(career -> !ANY.equals(career.getCareerType()))
-                .ifPresent(career -> queryParams.add(CAREER_TYPE_KEY, toCareerParam(career)));
+                .ifPresent(career -> queryParams.addAll(toCareerParam(career)));
         Optional.ofNullable(dto.getJobType())
                 .ifPresent(jobTypes -> queryParams.addAll(JOB_TYPE_KEY, toJobTypeParam(jobTypes)));
         Optional.ofNullable(dto.getPay())
@@ -62,8 +62,11 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
                 .collect(Collectors.toList());
     }
 
-    private String toCareerParam(DetailedSearchDto.Career career) {
-        return career.getCareerType().rocketPunchCode();
+    private MultiValueMap<String, String> toCareerParam(DetailedSearchDto.Career career) {
+        MultiValueMap<String, String> careerParam = new LinkedMultiValueMap<>();
+        Optional.ofNullable(career.getCareerType())
+                .ifPresent(careerType -> careerParam.add(CAREER_TYPE_KEY, careerType.rocketPunchCode()));
+        return careerParam;
     }
 
     private String toPayParam(DetailedSearchDto.Pay pay) {

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
@@ -6,8 +6,6 @@ import flab.project.jobfinder.enums.JobType;
 import flab.project.jobfinder.enums.Location;
 import lombok.RequiredArgsConstructor;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
@@ -42,6 +42,7 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
     }
 
     private String toSearchTextParam(String searchText) {
+        searchText = searchText.replaceAll(" ", "%20");
         return SEARCH_TEXT_KEY + "=" + searchText;
     }
 

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
@@ -15,6 +15,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
 
+    public static final int PAY_UNIT = 10000;
+    public static final int MAX_PAY = 20000;
     private final RocketPunchPropertiesConfig config;
 
     @Override
@@ -52,10 +54,10 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
     }
 
     private String toLocationParam(List<Location> locations) {
-        StringBuilder sb = new StringBuilder("");
-        if (locations.isEmpty()) {
-            return sb.toString();
-        }
+        StringBuilder sb = new StringBuilder();
+//        if (locations.isEmpty()) {
+//            return sb.toString();
+//        }
         locations.stream()
                 .map(Location::rocketPunchCode)
                 .forEach(location -> sb.append("&location=").append(location));
@@ -66,27 +68,24 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
         StringBuilder params = new StringBuilder();
 
         Optional.ofNullable(career.getCareerType())
-                .ifPresent(careerType -> params.append("&careerType=").append(careerType.jobkoreaCode()));
-        Optional.ofNullable(career.getCareerMin())
-                .ifPresent(careerMin -> params.append("&careerMin=").append(careerMin));
-        Optional.ofNullable(career.getCareerMax())
-                .ifPresent(careerMax -> params.append("&careerMax=").append(careerMax));
+                .ifPresent(careerType -> params.append("&career_type=").append(careerType.jobkoreaCode()));
+//        Optional.ofNullable(career.getCareerMin())
+//                .ifPresent(careerMin -> params.append("&careerMin=").append(careerMin));
+//        Optional.ofNullable(career.getCareerMax())
+//                .ifPresent(careerMax -> params.append("&careerMax=").append(careerMax));
         return params.toString();
     }
 
     private String toPayParam(DetailedSearchDto.Pay pay) {
-        StringBuilder params = new StringBuilder();
+        StringBuilder params = new StringBuilder("&salary=");
 
-        Optional.ofNullable(pay.getPayType())
-                .ifPresent(payType -> params.append("&payType=").append(payType.jobkoreaCode()));
-        Optional.ofNullable(pay.getPayMin())
-                .ifPresent(payMin -> params.append("&payMin=").append(payMin));
-        Optional.ofNullable(pay.getPayMax())
-                .ifPresent(payMax -> params.append("&payMax=").append(payMax));
+        Integer payMin = Optional.ofNullable(pay.getPayMin()).orElse(0);
+        Integer payMax = Optional.ofNullable(pay.getPayMax()).orElse(MAX_PAY);
+        params.append(payMin * PAY_UNIT).append("-").append(payMax * PAY_UNIT);
         return params.toString();
     }
 
     private String toPageNumParam(int pageNum) {
-        return "&Page_No=" + pageNum;
+        return "&page=" + pageNum;
     }
 }

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
@@ -1,6 +1,5 @@
 package flab.project.jobfinder.service.crawler.generator;
 
-import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.enums.JobType;
 import flab.project.jobfinder.enums.Location;
@@ -8,8 +7,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -27,8 +24,6 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
     public static final String PAGE_KEY = "page";
     public static final String SEARCH_TEXT_KEY = "keywords";
     public static final String CAREER_TYPE_KEY = "career_type";
-
-    private final RocketPunchPropertiesConfig config;
 
     @Override
     public MultiValueMap<String, String> toQueryParams(DetailedSearchDto dto, int pageNum) {

--- a/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
+++ b/src/main/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGenerator.java
@@ -29,23 +29,23 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
 
     @Override
     public MultiValueMap<String, String> toQueryParams(DetailedSearchDto dto, int pageNum) {
-        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
 
         Optional.ofNullable(dto.getSearchText())
-                .ifPresent(searchText -> map.add(SEARCH_TEXT_KEY, searchText));
+                .ifPresent(searchText -> queryParams.add(SEARCH_TEXT_KEY, searchText));
         Optional.ofNullable(dto.getLocation())
-                .ifPresent(locations -> map.add(LOCATION_KEY, toLocationParam(locations)));
+                .ifPresent(locations -> queryParams.add(LOCATION_KEY, toLocationParam(locations)));
         Optional.ofNullable(dto.getCareer())
                 .filter(career -> !ANY.equals(career.getCareerType()))
-                .ifPresent(career -> map.add(CAREER_TYPE_KEY, toCareerParam(career)));
+                .ifPresent(career -> queryParams.add(CAREER_TYPE_KEY, toCareerParam(career)));
         Optional.ofNullable(dto.getJobType())
-                .ifPresent(jobTypes -> map.add(JOB_TYPE_KEY, toJobTypeParam(jobTypes)));
+                .ifPresent(jobTypes -> queryParams.add(JOB_TYPE_KEY, toJobTypeParam(jobTypes)));
         Optional.ofNullable(dto.getPay())
                 .filter(pay -> !(pay.getPayMin() == null && pay.getPayMax() == null))
-                .ifPresent(pay -> map.add(PAY_KEY, toPayParam(pay)));
-        map.add(PAGE_KEY, String.valueOf(pageNum));
+                .ifPresent(pay -> queryParams.add(PAY_KEY, toPayParam(pay)));
+        queryParams.add(PAGE_KEY, String.valueOf(pageNum));
 
-        return map;
+        return queryParams;
     }
 
     private String toJobTypeParam(List<JobType> jobTypes) {
@@ -65,14 +65,14 @@ public class RocketPunchQueryParamGenerator implements QueryParamGenerator {
     }
 
     private String toPayParam(DetailedSearchDto.Pay pay) {
-        StringBuilder params = new StringBuilder();
+        StringBuilder payParam = new StringBuilder();
 
         Integer payMin = Optional.ofNullable(pay.getPayMin()).orElse(0);
         Integer payMax = pay.getPayMax();
-        params.append(payMin * PAY_UNIT).append("-");
+        payParam.append(payMin * PAY_UNIT).append("-");
         if (payMax != null) {
-            params.append(payMax);
+            payParam.append(payMax);
         }
-        return params.toString();
+        return payParam.toString();
     }
 }

--- a/src/main/java/flab/project/jobfinder/service/parser/JobKoreaParserService.java
+++ b/src/main/java/flab/project/jobfinder/service/parser/JobKoreaParserService.java
@@ -1,6 +1,6 @@
 package flab.project.jobfinder.service.parser;
 
-import flab.project.jobfinder.config.JobKoreaPropertiesConfig;
+import flab.project.jobfinder.config.jobkorea.JobKoreaPropertiesConfig;
 import flab.project.jobfinder.dto.RecruitDto;
 import lombok.RequiredArgsConstructor;
 import org.jsoup.nodes.Element;

--- a/src/main/java/flab/project/jobfinder/service/parser/RocketPunchParserService.java
+++ b/src/main/java/flab/project/jobfinder/service/parser/RocketPunchParserService.java
@@ -1,0 +1,99 @@
+package flab.project.jobfinder.service.parser;
+
+import flab.project.jobfinder.config.JobKoreaPropertiesConfig;
+import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
+import flab.project.jobfinder.dto.RecruitDto;
+import lombok.RequiredArgsConstructor;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static flab.project.jobfinder.enums.Platform.JOBKOREA;
+
+@Component
+@RequiredArgsConstructor
+public class RocketPunchParserService implements ParserService {
+
+    private final RocketPunchPropertiesConfig config;
+
+    @Override
+    public List<RecruitDto> parse(Elements recruits) {
+        List<RecruitDto> recruitDtoList = new ArrayList<>();
+
+        for (Element recruit : recruits) {
+            Elements corpElement = recruit.select("div > div.post-list-corp > a");
+            Elements infoElement = recruit.select("div > div.post-list-info");
+            Elements optionElement = infoElement.select("p.option");
+            Elements etcElement = infoElement.select("p.etc");
+
+            RecruitDto recruitDto = getParseDto(corpElement, infoElement, optionElement, etcElement);
+            recruitDtoList.add(recruitDto);
+        }
+        return recruitDtoList;
+    }
+
+    private RecruitDto getParseDto(Elements corpElement, Elements infoElement, Elements optionElement, Elements etcElement) {
+        RecruitDto recruitDto = RecruitDto.builder()
+                .title(parseTitle(infoElement))
+                .corp(parseCorp(corpElement))
+                .url(parseUrl(corpElement))
+                .career(parseCareer(optionElement))
+                .location(parseLocation(optionElement))
+                .dueDate(parseDueDate(optionElement))
+                .jobType(parseJobType(optionElement))
+                .techStack(parseTechStack(etcElement))
+                .platform(JOBKOREA.koreaName())
+                .build();
+        return recruitDto;
+    }
+
+    private String parseTechStack(Elements etcElement) {
+        if (etcElement == null) {
+            return "";
+        }
+        return etcElement.text();
+    }
+
+    private String parseDueDate(Elements optionElement) {
+        if (optionElement == null) {
+            return "";
+        }
+        return optionElement.select("span.date").text();
+    }
+
+    private String parseLocation(Elements optionElement) {
+        if (optionElement == null) {
+            return "";
+        }
+        return optionElement.select("span.long").text();
+    }
+
+    private String parseJobType(Elements optionElement) {
+        if (optionElement == null) {
+            return "";
+        }
+        return optionElement.select("span").get(2).text();
+    }
+
+    private String parseCareer(Elements optionElement) {
+        if (optionElement == null) {
+            return "";
+        }
+        return optionElement.select("span.exp").text().replace("[^0-9]", "");
+    }
+
+    private String parseUrl(Elements corpElement) {
+        return config.getUrl() + corpElement.attr("href");
+    }
+
+    private String parseCorp(Elements corpElement) {
+        return corpElement.attr("title");
+    }
+
+    private String parseTitle(Elements infoElement) {
+        return infoElement.select("a").attr("title");
+    }
+}

--- a/src/main/java/flab/project/jobfinder/service/parser/RocketPunchParserService.java
+++ b/src/main/java/flab/project/jobfinder/service/parser/RocketPunchParserService.java
@@ -1,6 +1,6 @@
 package flab.project.jobfinder.service.parser;
 
-import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
+import flab.project.jobfinder.config.rocketpunch.RocketPunchPropertiesConfig;
 import flab.project.jobfinder.dto.RecruitDto;
 import lombok.RequiredArgsConstructor;
 import org.jsoup.nodes.Element;

--- a/src/main/java/flab/project/jobfinder/service/parser/RocketPunchParserService.java
+++ b/src/main/java/flab/project/jobfinder/service/parser/RocketPunchParserService.java
@@ -48,6 +48,8 @@ public class RocketPunchParserService implements ParserService {
                 .url(url)
                 .career(career)
                 .dueDate(dueDate)
+                .location("")
+                .jobType("")
                 .platform(ROCKETPUNCH.koreaName())
                 .build();
     }
@@ -59,15 +61,17 @@ public class RocketPunchParserService implements ParserService {
 
     //기간, 원격 유뮤, 등록 날짜 3개 순으로 되어 있으므로 첫 번째 span 값 가져옴
     private String parseDueDate(Element recruitDetail) {
-        Element dueDateElement = recruitDetail.select("div.job-dates > span").first();
-        if (dueDateElement == null) {
+        Element dueDate = recruitDetail.select("div.job-dates > span").first();
+        if (dueDate == null) {
             return "";
         }
-        return recruitDetail.text();
+        return dueDate.text();
     }
 
     private String parseCareer(Element recruitDetail) {
-        return recruitDetail.select("div.job-stat-info").text();
+        String info = recruitDetail.select("span.job-stat-info").text();
+        String[] infoArr = info.split("/");
+        return infoArr[infoArr.length - 1];
     }
 
     private String parseUrl(Element recruitDetail) {
@@ -76,7 +80,7 @@ public class RocketPunchParserService implements ParserService {
     }
 
     private String parseCorp(Element recruit) {
-        Elements companyName = recruit.select("div.company-name");
+        Elements companyName = recruit.select("h4.name > strong");
         return companyName.text();
     }
 

--- a/src/main/java/flab/project/jobfinder/service/parser/pagination/JobKoreaPaginationParser.java
+++ b/src/main/java/flab/project/jobfinder/service/parser/pagination/JobKoreaPaginationParser.java
@@ -1,0 +1,26 @@
+package flab.project.jobfinder.service.parser.pagination;
+
+import flab.project.jobfinder.config.PropertiesConfig;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JobKoreaPaginationParser extends PaginationParser {
+
+    private final static int RECRUIT_COUNT_PER_PAGE = 20;
+
+    @Override
+    public int getTotalPage(Document doc, PropertiesConfig config) {
+        int pageNum = getPageNum(doc, config);
+        //page가 1부터 시작하므로 1 더해줌
+        return pageNum / RECRUIT_COUNT_PER_PAGE + 1;
+    }
+
+    private int getPageNum(Document doc, PropertiesConfig config) {
+        String numSelector = config.getPageSelector();
+        String pageNumStr = doc.select(numSelector)
+                .text()
+                .replaceAll("[^0-9]", "");
+        return Integer.parseInt(pageNumStr);
+    }
+}

--- a/src/main/java/flab/project/jobfinder/service/parser/pagination/PaginationParser.java
+++ b/src/main/java/flab/project/jobfinder/service/parser/pagination/PaginationParser.java
@@ -1,0 +1,20 @@
+package flab.project.jobfinder.service.parser.pagination;
+
+import flab.project.jobfinder.config.PropertiesConfig;
+import org.jsoup.nodes.Document;
+
+public abstract class PaginationParser {
+
+    private final static int MIDDLE_OF_PAGES = 4;
+    private final static int FIRST_PAGE = 1;
+
+    public abstract int getTotalPage(Document doc, PropertiesConfig config);
+
+    public int getStartPage(int currentPage) {
+        //1, 2, 3, 4 페이지일 때는 startPage = 1
+        if (currentPage <= MIDDLE_OF_PAGES) {
+            return FIRST_PAGE;
+        }
+        return currentPage - MIDDLE_OF_PAGES;
+    }
+}

--- a/src/main/java/flab/project/jobfinder/service/parser/pagination/RocketPunchPaginationParser.java
+++ b/src/main/java/flab/project/jobfinder/service/parser/pagination/RocketPunchPaginationParser.java
@@ -1,0 +1,22 @@
+package flab.project.jobfinder.service.parser.pagination;
+
+import flab.project.jobfinder.config.PropertiesConfig;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RocketPunchPaginationParser extends PaginationParser {
+
+    @Override
+    public int getTotalPage(Document doc, PropertiesConfig config) {
+        String totalPageSelector = config.getPageSelector();
+
+        Elements select = doc.select(totalPageSelector);
+        if (select.size() == 0) {
+            return 1;
+        }
+        String totalPageStr = select.last().text();
+        return Integer.parseInt(totalPageStr);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,5 +11,5 @@ jobkorea.num-selector=div.recruit-info > div.list-filter-wrap > p > strong
 rocket-punch.url=https://www.rocketpunch.com
 rocket-punch.search-url=https://www.rocketpunch.com/api/jobs/template
 rocket-punch.delimiter=&
-rocket-punch.selector=div.recruit-info > div.lists > div > div.list-default > ul > li
-rocket-punch.num-selector=div.recruit-info > div.list-filter-wrap > p > strong
+rocket-punch.selector=div.company-list > div.company.item > div.content
+rocket-punch.num-selector=div.pagination > div.widescreen > a

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,6 @@ jobkorea.num-selector=div.recruit-info > div.list-filter-wrap > p > strong
 
 rocket-punch.url=https://www.rocketpunch.com
 rocket-punch.search-url=https://www.rocketpunch.com/jobs?
-rocket-punch.delimiter=%2C
+rocket-punch.delimiter=&
 rocket-punch.selector=div.recruit-info > div.lists > div > div.list-default > ul > li
 rocket-punch.num-selector=div.recruit-info > div.list-filter-wrap > p > strong

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,13 +3,13 @@
 spring.messages.basename=errors
 
 jobkorea.url=https://www.jobkorea.co.kr
-jobkorea.search-url=https://www.jobkorea.co.kr/Search/?
+jobkorea.search-url=https://www.jobkorea.co.kr/Search/
 jobkorea.delimiter=%2C
 jobkorea.selector=div.recruit-info > div.lists > div > div.list-default > ul > li
 jobkorea.num-selector=div.recruit-info > div.list-filter-wrap > p > strong
 
 rocket-punch.url=https://www.rocketpunch.com
-rocket-punch.search-url=https://www.rocketpunch.com/api/jobs/template?
+rocket-punch.search-url=https://www.rocketpunch.com/api/jobs/template
 rocket-punch.delimiter=&
 rocket-punch.selector=div.recruit-info > div.lists > div > div.list-default > ul > li
 rocket-punch.num-selector=div.recruit-info > div.list-filter-wrap > p > strong

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,7 @@ jobkorea.selector=div.recruit-info > div.lists > div > div.list-default > ul > l
 jobkorea.num-selector=div.recruit-info > div.list-filter-wrap > p > strong
 
 rocket-punch.url=https://www.rocketpunch.com
-rocket-punch.search-url=https://www.rocketpunch.com/jobs?
+rocket-punch.search-url=https://www.rocketpunch.com/api/jobs/template?
 rocket-punch.delimiter=&
 rocket-punch.selector=div.recruit-info > div.lists > div > div.list-default > ul > li
 rocket-punch.num-selector=div.recruit-info > div.list-filter-wrap > p > strong

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,10 +6,10 @@ jobkorea.url=https://www.jobkorea.co.kr
 jobkorea.search-url=https://www.jobkorea.co.kr/Search/
 jobkorea.delimiter=%2C
 jobkorea.selector=div.recruit-info > div.lists > div > div.list-default > ul > li
-jobkorea.num-selector=div.recruit-info > div.list-filter-wrap > p > strong
+jobkorea.page-selector=div.recruit-info > div.list-filter-wrap > p > strong
 
 rocket-punch.url=https://www.rocketpunch.com
 rocket-punch.search-url=https://www.rocketpunch.com/api/jobs/template
 rocket-punch.delimiter=&
 rocket-punch.selector=div.company-list > div.company.item > div.content
-rocket-punch.total-pageSelector=div.pagination > div.widescreen > a
+rocket-punch.page-selector=div.pagination > div.widescreen > a

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,4 +12,4 @@ rocket-punch.url=https://www.rocketpunch.com
 rocket-punch.search-url=https://www.rocketpunch.com/api/jobs/template
 rocket-punch.delimiter=&
 rocket-punch.selector=div.company-list > div.company.item > div.content
-rocket-punch.num-selector=div.pagination > div.widescreen > a
+rocket-punch.total-pageSelector=div.pagination > div.widescreen > a

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,9 @@ jobkorea.search-url=https://www.jobkorea.co.kr/Search/?
 jobkorea.delimiter=%2C
 jobkorea.selector=div.recruit-info > div.lists > div > div.list-default > ul > li
 jobkorea.num-selector=div.recruit-info > div.list-filter-wrap > p > strong
+
+rocket-punch.url=https://www.jobkorea.co.kr
+rocket-punch.search-url=https://www.jobkorea.co.kr/Search/?
+rocket-punch.delimiter=%2C
+rocket-punch.selector=div.recruit-info > div.lists > div > div.list-default > ul > li
+rocket-punch.num-selector=div.recruit-info > div.list-filter-wrap > p > strong

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,8 +8,8 @@ jobkorea.delimiter=%2C
 jobkorea.selector=div.recruit-info > div.lists > div > div.list-default > ul > li
 jobkorea.num-selector=div.recruit-info > div.list-filter-wrap > p > strong
 
-rocket-punch.url=https://www.jobkorea.co.kr
-rocket-punch.search-url=https://www.jobkorea.co.kr/Search/?
+rocket-punch.url=https://www.rocketpunch.com
+rocket-punch.search-url=https://www.rocketpunch.com/jobs?
 rocket-punch.delimiter=%2C
 rocket-punch.selector=div.recruit-info > div.lists > div > div.list-default > ul > li
 rocket-punch.num-selector=div.recruit-info > div.list-filter-wrap > p > strong

--- a/src/main/resources/templates/form.html
+++ b/src/main/resources/templates/form.html
@@ -15,7 +15,7 @@
         <div class="row">플랫폼</div>
         <div class="row">
             <div th:each="entry : ${platformMap}" class="form-check">
-                <input type="checkbox" th:field="*{platform}" th:value="${entry.value}">
+                <input type="radio" th:field="*{platform}" th:value="${entry.value}">
                 <label class="form-check-label" th:for="${#ids.prev('platform')}" th:text="${entry.key}  "></label>
                 <div class="field-error" th:errors="*{platform}">
                     검증 오류

--- a/src/test/java/flab/project/jobfinder/controller/JobKoreaJobFinderControllerTest.java
+++ b/src/test/java/flab/project/jobfinder/controller/JobKoreaJobFinderControllerTest.java
@@ -1,5 +1,6 @@
 package flab.project.jobfinder.controller;
 
+import flab.project.jobfinder.dto.PageDto;
 import flab.project.jobfinder.dto.RecruitDto;
 import flab.project.jobfinder.dto.RecruitPageDto;
 import flab.project.jobfinder.dto.SearchFormDto;
@@ -36,7 +37,8 @@ class JobKoreaJobFinderControllerTest {
     SearchFormDto searchFormDto;
     RecruitDto recruitDto;
     RecruitPageDto recruitPageDto;
-
+    PageDto pageDto;
+    
     @BeforeEach
     void init() {
         searchFormDto = new SearchFormDto();
@@ -58,10 +60,14 @@ class JobKoreaJobFinderControllerTest {
                 .techStack("spring")
                 .build();
 
+        pageDto = PageDto.builder()
+                .startPage(1)
+                .totalPage(1)
+                .build();
+
         recruitPageDto = RecruitPageDto.builder()
                 .recruitDtoList(List.of(recruitDto))
-                .totalPage(1)
-                .startPage(1)
+                .pageDto(pageDto)
                 .build();
     }
 

--- a/src/test/java/flab/project/jobfinder/controller/JobKoreaJobFinderControllerTest.java
+++ b/src/test/java/flab/project/jobfinder/controller/JobKoreaJobFinderControllerTest.java
@@ -15,7 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -26,8 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(JobFinderController.class)
-@ActiveProfiles("dev")
-class JobFinderControllerTest {
+class JobKoreaJobFinderControllerTest {
 
     @Autowired
     MockMvc mockMvc;

--- a/src/test/java/flab/project/jobfinder/controller/RocketPunchJobFinderControllerTest.java
+++ b/src/test/java/flab/project/jobfinder/controller/RocketPunchJobFinderControllerTest.java
@@ -1,5 +1,6 @@
 package flab.project.jobfinder.controller;
 
+import flab.project.jobfinder.dto.PageDto;
 import flab.project.jobfinder.dto.RecruitDto;
 import flab.project.jobfinder.dto.RecruitPageDto;
 import flab.project.jobfinder.dto.SearchFormDto;
@@ -36,6 +37,7 @@ class RocketPunchJobFinderControllerTest {
     SearchFormDto searchFormDto;
     RecruitDto recruitDto;
     RecruitPageDto recruitPageDto;
+    PageDto pageDto;
 
     @BeforeEach
     void init() {
@@ -58,10 +60,14 @@ class RocketPunchJobFinderControllerTest {
                 .techStack("spring")
                 .build();
 
+        pageDto = PageDto.builder()
+                .startPage(1)
+                .totalPage(1)
+                .build();
+
         recruitPageDto = RecruitPageDto.builder()
                 .recruitDtoList(List.of(recruitDto))
-                .totalPage(1)
-                .startPage(1)
+                .pageDto(pageDto)
                 .build();
     }
 

--- a/src/test/java/flab/project/jobfinder/controller/RocketPunchJobFinderControllerTest.java
+++ b/src/test/java/flab/project/jobfinder/controller/RocketPunchJobFinderControllerTest.java
@@ -1,0 +1,193 @@
+package flab.project.jobfinder.controller;
+
+import flab.project.jobfinder.dto.RecruitDto;
+import flab.project.jobfinder.dto.RecruitPageDto;
+import flab.project.jobfinder.dto.SearchFormDto;
+import flab.project.jobfinder.enums.CareerType;
+import flab.project.jobfinder.enums.Location;
+import flab.project.jobfinder.enums.PayType;
+import flab.project.jobfinder.enums.Platform;
+import flab.project.jobfinder.service.JobFindFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(JobFinderController.class)
+class RocketPunchJobFinderControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    JobFindFactory findFactory;
+
+    SearchFormDto searchFormDto;
+    RecruitDto recruitDto;
+    RecruitPageDto recruitPageDto;
+
+    @BeforeEach
+    void init() {
+        searchFormDto = new SearchFormDto();
+        searchFormDto.setPlatform(Platform.ROCKETPUNCH);
+        searchFormDto.setSearchText("spring");
+        searchFormDto.setPayType(PayType.ANNUAL);
+        searchFormDto.setCareerType(CareerType.SENIOR);
+        searchFormDto.setLocation(List.of(Location.SEOUL));
+        searchFormDto.setCurrentPage(1);
+
+        recruitDto = RecruitDto.builder()
+                .title("test title")
+                .jobType("test jobType")
+                .dueDate("test dueDate")
+                .corp("test corp")
+                .career("test career")
+                .location("test loc")
+                .platform("로켓펀치")
+                .techStack("spring")
+                .build();
+
+        recruitPageDto = RecruitPageDto.builder()
+                .recruitDtoList(List.of(recruitDto))
+                .totalPage(1)
+                .startPage(1)
+                .build();
+    }
+
+    @Test
+    @DisplayName("get 테스트")
+    void getTest() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get("/job-find"))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("post 성공 테스트")
+    void postSuccessTest() throws Exception {
+        given(findFactory.getRecruitPageDto(searchFormDto.getDetailedSearchDto(),
+                                            searchFormDto.getCurrentPage()))
+                .willReturn(recruitPageDto);
+
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post("/job-find")
+                        .param("searchText", "spring")
+                        .param("location", "SEOUL")
+                        .param("platform", "ROCKETPUNCH")
+                        .param("payType", "ANNUAL")
+                        .param("careerType", "SENIOR")
+                        .param("currentPage", "1")
+                        .contentType(MediaType.TEXT_HTML)
+                        .accept(MediaType.TEXT_HTML))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("post 실패 - 플랫폼 선택 안 함")
+    void postFail_PlatformIsNull() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post("/job-find")
+                        .param("searchText", "spring")
+                        .param("location", "SEOUL")
+                        .param("pay.payType", "ANNUAL")
+                        .param("career.careerType", "SENIOR")
+                        .param("currentPage", "1")
+                        .contentType(MediaType.TEXT_HTML)
+                        .accept(MediaType.TEXT_HTML))
+                .andExpect(status().isOk());    //200이 리턴되는게 맞나?
+    }
+
+    @Test
+    @DisplayName("post 실패 - currentPage 값 안 들어옴")
+    void postFail_CurrentPageNull() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post("/job-find")
+                        .param("platform", "ROCKETPUNCH")
+                        .contentType(MediaType.TEXT_HTML)
+                        .accept(MediaType.TEXT_HTML))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("post 실패 - currentPage 이상한 값 들어옴")
+    void postFail_WrongFormatOfCurrentPage() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post("/job-find")
+                        .param("platform", "ROCKETPUNCH")
+                        .param("currentPage", "-1")
+                        .contentType(MediaType.TEXT_HTML)
+                        .accept(MediaType.TEXT_HTML))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("post 실패 - careerMin 이상한 값 들어옴")
+    void postFail_WrongFormatOfCareerMin() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post("/job-find")
+                        .param("platform", "ROCKETPUNCH")
+                        .param("currentPage", "1")
+                        .param("careerMin", "aaa")
+                        .contentType(MediaType.TEXT_HTML)
+                        .accept(MediaType.TEXT_HTML))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("post 실패 - careerMax 이상한 값 들어옴")
+    void postFail_WrongFormatOfCareerMax() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post("/job-find")
+                        .param("platform", "ROCKETPUNCH")
+                        .param("currentPage", "1")
+                        .param("careerMax", "aaa")
+                        .contentType(MediaType.TEXT_HTML)
+                        .accept(MediaType.TEXT_HTML))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("post 실패 - payMin 이상한 값 들어옴")
+    void postFail_WrongFormatOfPayMin() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post("/job-find")
+                        .param("platform", "ROCKETPUNCH")
+                        .param("currentPage", "1")
+                        .param("payMin", "aaa")
+                        .contentType(MediaType.TEXT_HTML)
+                        .accept(MediaType.TEXT_HTML))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("post 실패 - payMax 이상한 값 들어옴")
+    void postFail_WrongFormatOfPayMax() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post("/job-find")
+                        .param("platform", "ROCKETPUNCH")
+                        .param("currentPage", "1")
+                        .param("payMax", "aaa")
+                        .contentType(MediaType.TEXT_HTML)
+                        .accept(MediaType.TEXT_HTML))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/flab/project/jobfinder/service/JobKoreaJobFindServiceTest.java
+++ b/src/test/java/flab/project/jobfinder/service/JobKoreaJobFindServiceTest.java
@@ -1,10 +1,9 @@
 package flab.project.jobfinder.service;
 
-import flab.project.jobfinder.config.JobKoreaPropertiesConfig;
+import flab.project.jobfinder.config.jobkorea.JobKoreaPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.dto.RecruitPageDto;
 import flab.project.jobfinder.enums.Platform;
-import flab.project.jobfinder.service.JobKoreaJobFindService;
 import flab.project.jobfinder.service.crawler.JobKoreaCrawlerService;
 import flab.project.jobfinder.service.crawler.generator.JobKoreaQueryParamGenerator;
 import flab.project.jobfinder.service.parser.JobKoreaParserService;

--- a/src/test/java/flab/project/jobfinder/service/JobKoreaJobFindServiceTest.java
+++ b/src/test/java/flab/project/jobfinder/service/JobKoreaJobFindServiceTest.java
@@ -3,6 +3,7 @@ package flab.project.jobfinder.service;
 import flab.project.jobfinder.config.JobKoreaPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.dto.RecruitPageDto;
+import flab.project.jobfinder.enums.Platform;
 import flab.project.jobfinder.service.JobKoreaJobFindService;
 import flab.project.jobfinder.service.crawler.JobKoreaCrawlerService;
 import flab.project.jobfinder.service.crawler.generator.JobKoreaQueryParamGenerator;
@@ -27,7 +28,7 @@ class JobKoreaJobFindServiceTest {
     @Test
     @DisplayName("실제 파싱 테스트")
     void parse_test() {
-        DetailedSearchDto dto = DetailedSearchDto.builder().searchText("spring").build();
+        DetailedSearchDto dto = DetailedSearchDto.builder().searchText("spring").platform(Platform.JOBKOREA).build();
 
         RecruitPageDto dtoList = parserService.findJobByPage(dto, 1);
 

--- a/src/test/java/flab/project/jobfinder/service/JobKoreaJobFindServiceTest.java
+++ b/src/test/java/flab/project/jobfinder/service/JobKoreaJobFindServiceTest.java
@@ -1,4 +1,4 @@
-package flab.project.jobfinder.service.parser;
+package flab.project.jobfinder.service;
 
 import flab.project.jobfinder.config.JobKoreaPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
@@ -6,6 +6,7 @@ import flab.project.jobfinder.dto.RecruitPageDto;
 import flab.project.jobfinder.service.JobKoreaJobFindService;
 import flab.project.jobfinder.service.crawler.JobKoreaCrawlerService;
 import flab.project.jobfinder.service.crawler.generator.JobKoreaQueryParamGenerator;
+import flab.project.jobfinder.service.parser.JobKoreaParserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/flab/project/jobfinder/service/JobKoreaJobFindServiceTest.java
+++ b/src/test/java/flab/project/jobfinder/service/JobKoreaJobFindServiceTest.java
@@ -8,6 +8,7 @@ import flab.project.jobfinder.service.JobKoreaJobFindService;
 import flab.project.jobfinder.service.crawler.JobKoreaCrawlerService;
 import flab.project.jobfinder.service.crawler.generator.JobKoreaQueryParamGenerator;
 import flab.project.jobfinder.service.parser.JobKoreaParserService;
+import flab.project.jobfinder.service.parser.pagination.JobKoreaPaginationParser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +18,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = {JobKoreaJobFindService.class, JobKoreaCrawlerService.class, JobKoreaQueryParamGenerator.class, JobKoreaParserService.class})
+@SpringBootTest(classes = {JobKoreaJobFindService.class, JobKoreaCrawlerService.class, JobKoreaQueryParamGenerator.class, JobKoreaParserService.class, JobKoreaPaginationParser.class})
 @EnableConfigurationProperties(value = JobKoreaPropertiesConfig.class)
 @TestPropertySource("classpath:application-dev.properties")
 class JobKoreaJobFindServiceTest {

--- a/src/test/java/flab/project/jobfinder/service/RocketPunchJobFindServiceTest.java
+++ b/src/test/java/flab/project/jobfinder/service/RocketPunchJobFindServiceTest.java
@@ -1,7 +1,7 @@
 package flab.project.jobfinder.service;
 
-import flab.project.jobfinder.config.RocketPunchConfig;
-import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
+import flab.project.jobfinder.config.rocketpunch.RocketPunchConfig;
+import flab.project.jobfinder.config.rocketpunch.RocketPunchPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.dto.RecruitPageDto;
 import flab.project.jobfinder.enums.Platform;

--- a/src/test/java/flab/project/jobfinder/service/RocketPunchJobFindServiceTest.java
+++ b/src/test/java/flab/project/jobfinder/service/RocketPunchJobFindServiceTest.java
@@ -1,0 +1,37 @@
+package flab.project.jobfinder.service;
+
+import flab.project.jobfinder.config.RocketPunchConfig;
+import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
+import flab.project.jobfinder.dto.DetailedSearchDto;
+import flab.project.jobfinder.dto.RecruitPageDto;
+import flab.project.jobfinder.enums.Platform;
+import flab.project.jobfinder.service.crawler.RocketPunchCrawlerService;
+import flab.project.jobfinder.service.parser.RocketPunchParserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = {RocketPunchJobFindService.class, RocketPunchCrawlerService.class, RocketPunchParserService.class, RocketPunchConfig.class})
+@EnableConfigurationProperties(value = RocketPunchPropertiesConfig.class)
+class RocketPunchJobFindServiceTest {
+
+    @Autowired
+    RocketPunchJobFindService parserService;
+
+    @Test
+    @DisplayName("실제 파싱 테스트")
+    void parse_test() {
+        DetailedSearchDto dto = DetailedSearchDto.builder()
+                .searchText("spring")
+                .platform(Platform.ROCKETPUNCH)
+                .build();
+
+        RecruitPageDto dtoList = parserService.findJobByPage(dto, 1);
+
+        assertThat(dtoList.getRecruitDtoList().isEmpty()).isFalse();
+    }
+}

--- a/src/test/java/flab/project/jobfinder/service/RocketPunchJobFindServiceTest.java
+++ b/src/test/java/flab/project/jobfinder/service/RocketPunchJobFindServiceTest.java
@@ -7,6 +7,7 @@ import flab.project.jobfinder.dto.RecruitPageDto;
 import flab.project.jobfinder.enums.Platform;
 import flab.project.jobfinder.service.crawler.RocketPunchCrawlerService;
 import flab.project.jobfinder.service.parser.RocketPunchParserService;
+import flab.project.jobfinder.service.parser.pagination.RocketPunchPaginationParser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = {RocketPunchJobFindService.class, RocketPunchCrawlerService.class, RocketPunchParserService.class, RocketPunchConfig.class})
+@SpringBootTest(classes = {RocketPunchJobFindService.class, RocketPunchCrawlerService.class, RocketPunchParserService.class, RocketPunchConfig.class, RocketPunchPaginationParser.class})
 @EnableConfigurationProperties(value = RocketPunchPropertiesConfig.class)
 class RocketPunchJobFindServiceTest {
 

--- a/src/test/java/flab/project/jobfinder/service/crawler/JobKoreaCrawlerServiceTest.java
+++ b/src/test/java/flab/project/jobfinder/service/crawler/JobKoreaCrawlerServiceTest.java
@@ -1,6 +1,6 @@
 package flab.project.jobfinder.service.crawler;
 
-import flab.project.jobfinder.config.JobKoreaPropertiesConfig;
+import flab.project.jobfinder.config.jobkorea.JobKoreaPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.service.crawler.generator.JobKoreaQueryParamGenerator;
 import org.jsoup.nodes.Document;

--- a/src/test/java/flab/project/jobfinder/service/crawler/JobKoreaCrawlerServiceTest.java
+++ b/src/test/java/flab/project/jobfinder/service/crawler/JobKoreaCrawlerServiceTest.java
@@ -10,7 +10,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
+import java.util.List;
+import java.util.Map;
+
+import static flab.project.jobfinder.enums.Location.BUNDANG;
+import static flab.project.jobfinder.enums.Location.GANGNAM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -28,11 +35,12 @@ class JobKoreaCrawlerServiceTest {
 
     @Test
     void 크롤링_정상_작동_테스트() {
-        String givenText = "spring";
-        DetailedSearchDto dto = DetailedSearchDto.builder().searchText(givenText).build();
-
-        when(paramGenerator.toQueryParams(dto, 1)).thenReturn("stext=" + givenText);
-        when(jobKoreaPropertiesConfig.getSearchUrl()).thenReturn("https://www.jobkorea.co.kr/Search/?tabType=recruit&Page_No=1");
+        DetailedSearchDto dto = DetailedSearchDto.builder().searchText("spring").location(List.of(GANGNAM, BUNDANG)).build();
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>(Map.of(
+                "stext", List.of("웹 서비스"),
+                "local", List.of("I010", "B150")));
+        when(paramGenerator.toQueryParams(dto, 1)).thenReturn(map);
+        when(jobKoreaPropertiesConfig.getSearchUrl()).thenReturn("https://www.jobkorea.co.kr/Search/");
 
         Document result = jobKoreaCrawlerService.crawl(dto, 1);
 

--- a/src/test/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerServiceTest.java
+++ b/src/test/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerServiceTest.java
@@ -1,6 +1,6 @@
 package flab.project.jobfinder.service.crawler;
 
-import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
+import flab.project.jobfinder.config.rocketpunch.RocketPunchPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import flab.project.jobfinder.service.crawler.generator.RocketPunchQueryParamGenerator;
 import lombok.extern.slf4j.Slf4j;

--- a/src/test/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerServiceTest.java
+++ b/src/test/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerServiceTest.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -50,6 +49,5 @@ class RocketPunchCrawlerServiceTest {
         Document result = rocketPunchCrawlerService.crawl(dto, 1);
 
         assertThat(result).isNotNull();
-        assertThat(result.connection().response().statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 }

--- a/src/test/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerServiceTest.java
+++ b/src/test/java/flab/project/jobfinder/service/crawler/RocketPunchCrawlerServiceTest.java
@@ -1,0 +1,55 @@
+package flab.project.jobfinder.service.crawler;
+
+import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
+import flab.project.jobfinder.dto.DetailedSearchDto;
+import flab.project.jobfinder.service.crawler.generator.RocketPunchQueryParamGenerator;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+import java.util.List;
+import java.util.Map;
+
+import static flab.project.jobfinder.enums.Location.BUNDANG;
+import static flab.project.jobfinder.enums.Location.GANGNAM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Slf4j
+class RocketPunchCrawlerServiceTest {
+
+    RocketPunchCrawlerService rocketPunchCrawlerService;
+    RocketPunchPropertiesConfig rocketPunchPropertiesConfig;
+    RocketPunchQueryParamGenerator paramGenerator;
+    WebClient webClient;
+
+    @BeforeEach
+    void init() {
+        rocketPunchPropertiesConfig = mock(RocketPunchPropertiesConfig.class);
+        paramGenerator = mock(RocketPunchQueryParamGenerator.class);
+        webClient = WebClient.builder()
+                .baseUrl("https://www.rocketpunch.com/api/jobs/template")
+                .build();
+        rocketPunchCrawlerService = new RocketPunchCrawlerService(paramGenerator, rocketPunchPropertiesConfig, webClient);
+    }
+
+    @Test
+    void 크롤링_정상_작동_테스트() {
+        DetailedSearchDto dto = DetailedSearchDto.builder().searchText("spring").location(List.of(GANGNAM, BUNDANG)).build();
+        MultiValueMap<String, String> map = new LinkedMultiValueMap<>(Map.of(
+                "keywords", List.of("웹 서비스"),
+                "location", List.of("강남구", "분당구")));
+        when(paramGenerator.toQueryParams(dto, 1)).thenReturn(map);
+        when(rocketPunchPropertiesConfig.getSearchUrl()).thenReturn("https://www.rocketpunch.com/api/jobs/template");
+
+        Document result = rocketPunchCrawlerService.crawl(dto, 1);
+
+        assertThat(result).isNotNull();
+        assertThat(result.connection().response().statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+}

--- a/src/test/java/flab/project/jobfinder/service/crawler/generator/JobKoreaQueryParamGeneratorTest.java
+++ b/src/test/java/flab/project/jobfinder/service/crawler/generator/JobKoreaQueryParamGeneratorTest.java
@@ -1,6 +1,5 @@
 package flab.project.jobfinder.service.crawler.generator;
 
-import flab.project.jobfinder.config.JobKoreaPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.TestInstance;
@@ -9,10 +8,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static flab.project.jobfinder.enums.CareerType.JUNIOR;
@@ -20,7 +21,6 @@ import static flab.project.jobfinder.enums.JobType.MILITARY;
 import static flab.project.jobfinder.enums.Location.*;
 import static flab.project.jobfinder.enums.PayType.ANNUAL;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(MockitoExtension.class)
@@ -29,50 +29,57 @@ class JobKoreaQueryParamGeneratorTest {
     @InjectMocks
     JobKoreaQueryParamGenerator jobKoreaQueryParamGenerator;
 
-    @Mock
-    JobKoreaPropertiesConfig config;
-
     @ParameterizedTest(name = "{index} => {1}")
     @MethodSource("provideDto")
-    @DisplayName("정상 url 리턴")
-    void 정상_url_리턴(DetailedSearchDto dto, String expected) {
-        String result =  jobKoreaQueryParamGenerator.toQueryParams(dto, 1);
+    @DisplayName("정상 QueryParameter 리턴")
+    void 정상_url_리턴_Delimiter_사용(DetailedSearchDto dto, MultiValueMap<String, String> expected) {
+        MultiValueMap<String, String> result =  jobKoreaQueryParamGenerator.toQueryParams(dto, 1);
 
         assertThat(result).isEqualTo(expected);
-    }
-
-    @ParameterizedTest(name = "{index} => {1}")
-    @MethodSource("provideDtoUsingDelimiter")
-    @DisplayName("정상 url 리턴 구분자 사용")
-    void 정상_url_리턴_Delimiter_사용(DetailedSearchDto dto, String expected) {
-        when(config.getDelimiter()).thenReturn("%2C");
-
-        String result =  jobKoreaQueryParamGenerator.toQueryParams(dto, 1);
-
-        assertThat(result).isEqualTo(expected);
-    }
-
-    private Stream<Arguments> provideDtoUsingDelimiter() {
-        return Stream.of(
-                Arguments.of(DetailedSearchDto.builder().searchText("웹 서비스")
-                        .location(List.of(GANGNAM, BUNDANG))
-                        .pay(new DetailedSearchDto.Pay(ANNUAL, 4000, null)).build()
-                        , "tabType=recruit&stext=%EC%9B%B9+%EC%84%9C%EB%B9%84%EC%8A%A4&local=I010%2CB150&payType=1&payMin=4000&Page_No=1")
-
-        );
     }
 
     private Stream<Arguments> provideDto() {
+        MultiValueMap<String, String> map1 = new LinkedMultiValueMap<>(Map.of(
+                "tabType", List.of("recruit"),
+                "Page_No", List.of("1")));
+        MultiValueMap<String, String> map2 = new LinkedMultiValueMap<>(Map.of(
+                "tabType", List.of("recruit"),
+                "stext", List.of("spring"),
+                "Page_No", List.of("1")));
+        MultiValueMap<String, String> map3 = new LinkedMultiValueMap<>(Map.of(
+                "tabType", List.of("recruit"),
+                "stext", List.of("spring boot"),
+                "careerType", List.of("1"),
+                "careerMax", List.of("2"),
+                "Page_No", List.of("1")));
+        MultiValueMap<String, String> map4 = new LinkedMultiValueMap<>(Map.of(
+                "tabType", List.of("recruit"),
+                "stext", List.of("react 웹 프런트"),
+                "local", List.of("I110", "I220", "I210"),
+                "jobtype", List.of("9"),
+                "Page_No", List.of("1")));
+        MultiValueMap<String, String> map5 = new LinkedMultiValueMap<>(Map.of(
+                "tabType", List.of("recruit"),
+                "stext", List.of("웹 서비스"),
+                "local", List.of("I010", "B150"),
+                "payType", List.of("1"),
+                "payMin", List.of("4000"),
+                "Page_No", List.of("1")));
+
         return Stream.of(
-                Arguments.of(DetailedSearchDto.builder().build(), "tabType=recruit&Page_No=1"),
-                Arguments.of(DetailedSearchDto.builder().searchText("spring").build(), "tabType=recruit&stext=spring&Page_No=1"),
+                Arguments.of(DetailedSearchDto.builder().build(), map1),
+                Arguments.of(DetailedSearchDto.builder().searchText("spring").build(), map2),
                 Arguments.of(DetailedSearchDto.builder().searchText("spring boot")
                                 .career(new DetailedSearchDto.Career(JUNIOR, null, 2)).build()
-                        , "tabType=recruit&stext=spring+boot&careerType=1&careerMax=2&Page_No=1"),
+                        , map3),
                 Arguments.of(DetailedSearchDto.builder().searchText("react 웹 프런트")
                                 .location(List.of(DONGDAEMUN, EUNPYEONG, YONGSAN))
                                 .jobType(List.of(MILITARY)).build()
-                        , "tabType=recruit&stext=react+%EC%9B%B9+%ED%94%84%EB%9F%B0%ED%8A%B8&local=I110%2CI220%2CI210&jobtype=9&Page_No=1")
+                        , map4),
+                Arguments.of(DetailedSearchDto.builder().searchText("웹 서비스")
+                                .location(List.of(GANGNAM, BUNDANG))
+                                .pay(new DetailedSearchDto.Pay(ANNUAL, 4000, null)).build()
+                        , map5)
         );
     }
 }

--- a/src/test/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGeneratorTest.java
+++ b/src/test/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGeneratorTest.java
@@ -1,0 +1,70 @@
+package flab.project.jobfinder.service.crawler.generator;
+
+import flab.project.jobfinder.config.JobKoreaPropertiesConfig;
+import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
+import flab.project.jobfinder.dto.DetailedSearchDto;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static flab.project.jobfinder.enums.CareerType.JUNIOR;
+import static flab.project.jobfinder.enums.JobType.MILITARY;
+import static flab.project.jobfinder.enums.Location.*;
+import static flab.project.jobfinder.enums.PayType.ANNUAL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
+class RocketPunchQueryParamGeneratorTest {
+
+    RocketPunchQueryParamGenerator rocketPunchQueryParamGenerator;
+
+    RocketPunchPropertiesConfig config;
+
+    @BeforeAll
+    void init() {
+        config = mock(RocketPunchPropertiesConfig.class);
+        rocketPunchQueryParamGenerator = new RocketPunchQueryParamGenerator(config);
+
+        given(config.getDelimiter()).willReturn("&");
+    }
+
+    @ParameterizedTest(name = "{index} => {1}")
+    @MethodSource("provideDto")
+    @DisplayName("정상 url 리턴")
+    void 정상_url_리턴(DetailedSearchDto dto, String expected) {
+        String result =  rocketPunchQueryParamGenerator.toQueryParams(dto, 1);
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    private Stream<Arguments> provideDto() {
+        return Stream.of(
+                Arguments.of(DetailedSearchDto.builder().searchText("spring").build(), "keywords=spring&page=1"),
+                Arguments.of(DetailedSearchDto.builder().searchText("spring boot")
+                                .career(new DetailedSearchDto.Career(JUNIOR, null, 2)).build()
+                        , "keywords=spring%20boot&career_type=1&page=1"),
+                Arguments.of(DetailedSearchDto.builder().searchText("웹 서비스")
+                                .location(List.of(GANGNAM, BUNDANG))
+                                .pay(new DetailedSearchDto.Pay(ANNUAL, 4000, null)).build()
+                        , "keywords=웹%20서비스&location=강남구&location=분당구&salary=40000000-200000000&page=1"),
+                Arguments.of(DetailedSearchDto.builder().searchText("react 웹 프런트")
+                                .location(List.of(DONGDAEMUN, EUNPYEONG, YONGSAN))
+                                .jobType(List.of(MILITARY)).build()
+                        , "keywords=react%20웹%20프런트&location=동대문구&location=은평구&location=용산구&hiring_types=3&page=1")
+        );
+    }
+}

--- a/src/test/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGeneratorTest.java
+++ b/src/test/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGeneratorTest.java
@@ -1,6 +1,5 @@
 package flab.project.jobfinder.service.crawler.generator;
 
-import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -19,22 +18,15 @@ import static flab.project.jobfinder.enums.JobType.MILITARY;
 import static flab.project.jobfinder.enums.Location.*;
 import static flab.project.jobfinder.enums.PayType.ANNUAL;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RocketPunchQueryParamGeneratorTest {
 
     RocketPunchQueryParamGenerator rocketPunchQueryParamGenerator;
 
-    RocketPunchPropertiesConfig config;
-
-    @BeforeAll
+    @BeforeEach
     void init() {
-        config = mock(RocketPunchPropertiesConfig.class);
-        rocketPunchQueryParamGenerator = new RocketPunchQueryParamGenerator(config);
-
-        given(config.getDelimiter()).willReturn("&");
+        rocketPunchQueryParamGenerator = new RocketPunchQueryParamGenerator();
     }
 
     @ParameterizedTest(name = "{index} => {1}")

--- a/src/test/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGeneratorTest.java
+++ b/src/test/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGeneratorTest.java
@@ -58,12 +58,12 @@ class RocketPunchQueryParamGeneratorTest {
                 "page", List.of("1")));
         MultiValueMap<String, String> map4 = new LinkedMultiValueMap<>(Map.of(
                 "keywords", List.of("react 웹 프런트"),
-                "location", List.of("동대문구&location=은평구&location=용산구"),
+                "location", List.of("동대문구", "은평구", "용산구"),
                 "hiring_types", List.of("3"),
                 "page", List.of("1")));
         MultiValueMap<String, String> map5 = new LinkedMultiValueMap<>(Map.of(
                 "keywords", List.of("웹 서비스"),
-                "location", List.of("강남구&location=분당구"),
+                "location", List.of("강남구", "분당구"),
                 "salary", List.of("40000000-"),
                 "page", List.of("1")));
         MultiValueMap<String, String> map6 = new LinkedMultiValueMap<>(Map.of(

--- a/src/test/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGeneratorTest.java
+++ b/src/test/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGeneratorTest.java
@@ -1,23 +1,19 @@
 package flab.project.jobfinder.service.crawler.generator;
 
-import flab.project.jobfinder.config.JobKoreaPropertiesConfig;
 import flab.project.jobfinder.config.RocketPunchPropertiesConfig;
 import flab.project.jobfinder.dto.DetailedSearchDto;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
+import static flab.project.jobfinder.enums.CareerType.ANY;
 import static flab.project.jobfinder.enums.CareerType.JUNIOR;
 import static flab.project.jobfinder.enums.JobType.MILITARY;
 import static flab.project.jobfinder.enums.Location.*;
@@ -27,7 +23,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ExtendWith(MockitoExtension.class)
 class RocketPunchQueryParamGeneratorTest {
 
     RocketPunchQueryParamGenerator rocketPunchQueryParamGenerator;
@@ -45,26 +40,53 @@ class RocketPunchQueryParamGeneratorTest {
     @ParameterizedTest(name = "{index} => {1}")
     @MethodSource("provideDto")
     @DisplayName("정상 url 리턴")
-    void 정상_url_리턴(DetailedSearchDto dto, String expected) {
-        String result =  rocketPunchQueryParamGenerator.toQueryParams(dto, 1);
+    void 정상_url_리턴(DetailedSearchDto dto, MultiValueMap<String, String> expected) {
+        MultiValueMap<String, String> result =  rocketPunchQueryParamGenerator.toQueryParams(dto, 1);
 
         assertThat(result).isEqualTo(expected);
     }
 
     private Stream<Arguments> provideDto() {
+        MultiValueMap<String, String> map1 = new LinkedMultiValueMap<>(Map.of(
+                "page", List.of("1")));
+        MultiValueMap<String, String> map2 = new LinkedMultiValueMap<>(Map.of(
+                "keywords", List.of("spring"),
+                "page", List.of("1")));
+        MultiValueMap<String, String> map3 = new LinkedMultiValueMap<>(Map.of(
+                "keywords", List.of("spring boot"),
+                "career_type", List.of("1"),
+                "page", List.of("1")));
+        MultiValueMap<String, String> map4 = new LinkedMultiValueMap<>(Map.of(
+                "keywords", List.of("react 웹 프런트"),
+                "location", List.of("동대문구&location=은평구&location=용산구"),
+                "hiring_types", List.of("3"),
+                "page", List.of("1")));
+        MultiValueMap<String, String> map5 = new LinkedMultiValueMap<>(Map.of(
+                "keywords", List.of("웹 서비스"),
+                "location", List.of("강남구&location=분당구"),
+                "salary", List.of("40000000-"),
+                "page", List.of("1")));
+        MultiValueMap<String, String> map6 = new LinkedMultiValueMap<>(Map.of(
+                "keywords", List.of("테스트"),
+                "page", List.of("1")));
+
         return Stream.of(
-                Arguments.of(DetailedSearchDto.builder().searchText("spring").build(), "keywords=spring&page=1"),
+                Arguments.of(DetailedSearchDto.builder().build(), map1),
+                Arguments.of(DetailedSearchDto.builder().searchText("spring").build(), map2),
                 Arguments.of(DetailedSearchDto.builder().searchText("spring boot")
                                 .career(new DetailedSearchDto.Career(JUNIOR, null, 2)).build()
-                        , "keywords=spring+boot&career_type=1&page=1"),
-                Arguments.of(DetailedSearchDto.builder().searchText("웹 서비스")
-                                .location(List.of(GANGNAM, BUNDANG))
-                                .pay(new DetailedSearchDto.Pay(ANNUAL, 4000, null)).build()
-                        , "keywords=%EC%9B%B9+%EC%84%9C%EB%B9%84%EC%8A%A4&location=%EA%B0%95%EB%82%A8%EA%B5%AC&location=%EB%B6%84%EB%8B%B9%EA%B5%AC&salary=40000000-200000000&page=1"),
+                        , map3),
                 Arguments.of(DetailedSearchDto.builder().searchText("react 웹 프런트")
                                 .location(List.of(DONGDAEMUN, EUNPYEONG, YONGSAN))
                                 .jobType(List.of(MILITARY)).build()
-                        , "keywords=react+%EC%9B%B9+%ED%94%84%EB%9F%B0%ED%8A%B8&location=%EB%8F%99%EB%8C%80%EB%AC%B8%EA%B5%AC&location=%EC%9D%80%ED%8F%89%EA%B5%AC&location=%EC%9A%A9%EC%82%B0%EA%B5%AC&hiring_types=3&page=1")
+                        , map4),
+                Arguments.of(DetailedSearchDto.builder().searchText("웹 서비스")
+                                .location(List.of(GANGNAM, BUNDANG))
+                                .pay(new DetailedSearchDto.Pay(ANNUAL, 4000, null)).build()
+                        , map5),
+                Arguments.of(DetailedSearchDto.builder().searchText("테스트")
+                                .career(new DetailedSearchDto.Career(ANY, 1, null)).build()
+                        , map6)
         );
     }
 }

--- a/src/test/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGeneratorTest.java
+++ b/src/test/java/flab/project/jobfinder/service/crawler/generator/RocketPunchQueryParamGeneratorTest.java
@@ -56,15 +56,15 @@ class RocketPunchQueryParamGeneratorTest {
                 Arguments.of(DetailedSearchDto.builder().searchText("spring").build(), "keywords=spring&page=1"),
                 Arguments.of(DetailedSearchDto.builder().searchText("spring boot")
                                 .career(new DetailedSearchDto.Career(JUNIOR, null, 2)).build()
-                        , "keywords=spring%20boot&career_type=1&page=1"),
+                        , "keywords=spring+boot&career_type=1&page=1"),
                 Arguments.of(DetailedSearchDto.builder().searchText("웹 서비스")
                                 .location(List.of(GANGNAM, BUNDANG))
                                 .pay(new DetailedSearchDto.Pay(ANNUAL, 4000, null)).build()
-                        , "keywords=웹%20서비스&location=강남구&location=분당구&salary=40000000-200000000&page=1"),
+                        , "keywords=%EC%9B%B9+%EC%84%9C%EB%B9%84%EC%8A%A4&location=%EA%B0%95%EB%82%A8%EA%B5%AC&location=%EB%B6%84%EB%8B%B9%EA%B5%AC&salary=40000000-200000000&page=1"),
                 Arguments.of(DetailedSearchDto.builder().searchText("react 웹 프런트")
                                 .location(List.of(DONGDAEMUN, EUNPYEONG, YONGSAN))
                                 .jobType(List.of(MILITARY)).build()
-                        , "keywords=react%20웹%20프런트&location=동대문구&location=은평구&location=용산구&hiring_types=3&page=1")
+                        , "keywords=react+%EC%9B%B9+%ED%94%84%EB%9F%B0%ED%8A%B8&location=%EB%8F%99%EB%8C%80%EB%AC%B8%EA%B5%AC&location=%EC%9D%80%ED%8F%89%EA%B5%AC&location=%EC%9A%A9%EC%82%B0%EA%B5%AC&hiring_types=3&page=1")
         );
     }
 }


### PR DESCRIPTION
로켓펀치 크롤링 서비스 구현했습니다.

구현하는 과정에서 `JobFindService`에 있는 `pagination`관련 처리하는 부분과 `ParamGenerator`에 관한 부분의 리팩토링을 진행했습니다.

`pagination` 부분은 각 `JobFindService`에 맞게 분리하는 정도로 진행했습니다.

`ParamGenerator`는 기존에 쿼리스트링을 만들어 `String`타입으로 리턴하던 방식에서 `MultiValueMap<String, String>`의 방식으로 리턴하도록 변경했습니다.
사실 이 부분은 여러 이유가 있어서 리팩토링을 진행했는데 지금 생각해보니 쉽게 해결 가능한 부분이었네요 😂

그리고 쿼리스트링에 같은 key여도 배열을 사용하지 않고 쿼리를 여러 번 적는 방식(`location=강남구, 분당구`가 아닌 `location=강남구&location=분당구`와 같은 방식)이어서 `MultiValueMap`으로 리팩토링한 의미가 많이 사라졌습니다.

이 때문에 `MultiValueMap`보다 `URI`를 리턴하도록 하는 방식이 좀 더 괜찮을 것 같다는 생각이 들어 추후에 시간이 되면 다시 리팩토링을 진행할까 합니다..😭

그리고 생각보다 잡코리아와 다른 방식이 많아서 코드가 조금 난잡해졌습니다. 

예를 들어 잡코리아에는 고용형태(`JobType`)에 인턴이 들어가 있는 반면 로켓펀치에는 경력(`Career`)에 인턴이 들어가 있었고,
검색 결과의 형식이 맞지 않는다던지, 검색 조건에 대한 채용 공고를 포함한 회사의 모든 채용 글을 나타내서 결과가 만족스럽게 나오지는 않았습니다. 

또한 왜인지는 잘 모르겠지만 맨 처음 `request`를 보내면 html의 `fragment`를 받아오고 서버에 다시 api요청을 보내 `template`를 받아오는 방식으로 되어있어서 이 부분을 알아내는데 시간이 조금 걸린 것 같습니다.